### PR TITLE
Enhancement/31 use previous stable version instead of 3.10.9

### DIFF
--- a/src/features/delete-plugin.feature
+++ b/src/features/delete-plugin.feature
@@ -5,13 +5,13 @@ Feature: C4466 - Should successfully delete the plugin
         Given I am logged in
 
     Scenario: WP Rocket is installed but not activated
-        Given plugin is installed
+        Given plugin is installed 'new_release'
         When I delete plugin
         Then plugin should delete successfully
         But I must not see any error in debug.log
 
     Scenario: WP Rocket is installed and activated
-        Given plugin is installed
+        Given plugin is installed 'new_release'
         And plugin is activated
         When I go to 'wp-admin/options-general.php?page=wprocket#dashboard'
         And I enable all settings

--- a/src/features/enable-all-features.feature
+++ b/src/features/enable-all-features.feature
@@ -3,7 +3,7 @@ Feature: C1205 - Enabling all WP Rocket features should not throw any fatal erro
 
     Background:
         Given I am logged in
-        And plugin is installed
+        And plugin is installed 'new_release'
         And plugin is activated
 
     Scenario: Enable all features

--- a/src/features/roll-back.feature
+++ b/src/features/roll-back.feature
@@ -3,7 +3,7 @@ Feature: C11856 - Should roll back to the last previous major version when using
 
     Background:
         Given I am logged in
-        And plugin is installed
+        And plugin is installed 'new_release'
         And plugin is activated
 
     Scenario: Roll back from the tools tab

--- a/src/features/settings-export-import.feature
+++ b/src/features/settings-export-import.feature
@@ -1,11 +1,11 @@
-@smoke @local
+@smoke @local @export
 Feature: C2148 - Should not change the content of existing fields
 
     Background:
         Given I am logged in
 
     Scenario: Data imported correctly
-        Given a previous version of plugin is installed
+        Given plugin is installed 'previous_stable'
         And plugin is activated
         And I disabled all settings
         And I saved specific settings 'cache' 'cacheLoggedUser'
@@ -21,7 +21,7 @@ Feature: C2148 - Should not change the content of existing fields
         Then data '2' is exported correctly
 
     Scenario: Data exported correctly on latest version
-        Given I updated to latest version
+        Given I updated plugin to 'new_release'
         And I disabled all settings
         And I saved specific settings 'media' 'lazyload'
         When I export data '3'

--- a/src/features/upgrading-plugin.feature
+++ b/src/features/upgrading-plugin.feature
@@ -1,24 +1,24 @@
-@smoke @online
-Feature: C11513 - Should not cause fatal error when upgrade from 3.10.9 to latest version while using PHP 8.1.6 while beacon is open
+@online
+Feature: C11513 - Should not cause fatal error when upgrade from previous version to latest version while using PHP 8.1.6 while beacon is open
 
     Background:
         Given I am logged in
 
-    Scenario: With version 3.10.9 Installed
-        Given plugin 3.10.9 is installed
+    Scenario: With previous version Installed
+        Given plugin is installed 'previous_stable'
         And plugin is activated
         And I go to 'wp-admin/options-general.php?page=wprocket#file_optimization'
         And rucss beacon is opened
 
     Scenario: Update to latest version
-        When I update to latest version
+        Given I updated plugin to 'new_release'
         And I go to 'wp-admin/options-general.php?page=wprocket#file_optimization'
         And rucss beacon is opened
         And I go through rucss beacon
         Then I must not see any error in debug.log
 
     Scenario: Downngrade to last stable version
-        When I downgrade to the last stable version
+        Given I updated plugin to 'previous_stable'
         And I go to 'wp-admin/options-general.php?page=wprocket#file_optimization'
         And rucss beacon is opened
         And I go through rucss beacon

--- a/src/support/steps/general.ts
+++ b/src/support/steps/general.ts
@@ -9,10 +9,20 @@ Given('I am logged in', async function (this: ICustomWorld) {
     await this.utils.auth();
 });
 
-Given('plugin is installed', async function (this: ICustomWorld) {
-    await this.utils.uploadNewPlugin('./plugin/new_release.zip');
+Given('plugin is installed {string}', async function (this: ICustomWorld, pluginVersion: string) {
+    await this.utils.uploadNewPlugin(`./plugin/${pluginVersion}.zip`);
     await this.page.waitForLoadState('load', { timeout: 30000 });
     await expect(this.page).toHaveURL(/action=upload-plugin/); 
+});
+
+Given('I updated plugin to {string}', async function (this: ICustomWorld, pluginVersion: string) {
+    await this.utils.uploadNewPlugin(`./plugin/${pluginVersion}.zip`);
+    await this.page.waitForLoadState('load', { timeout: 30000 });
+    await expect(this.page).toHaveURL(/action=upload-plugin/); 
+    
+    // Replace current with uploaded
+    await this.page.locator('a:has-text("Replace current with uploaded")').click();
+    await this.page.waitForLoadState('load', { timeout: 30000 });
 });
 
 Given('plugin is activated', async function (this: ICustomWorld) {

--- a/src/support/steps/settings-export-import.ts
+++ b/src/support/steps/settings-export-import.ts
@@ -20,18 +20,6 @@ Given('I saved specific settings {string} {string}', async function (this: ICust
     await this.page.waitForLoadState('load', { timeout: 30000 });
 });
 
-Given('I updated to latest version', async function (this: ICustomWorld) {
-    await this.utils.uploadNewPlugin('./plugin/new_release.zip');
-    await this.page.waitForLoadState('load', { timeout: 30000 });
-    await expect(this.page).toHaveURL(/action=upload-plugin/); 
-    
-    // Replace current with uploaded
-    await this.page.locator('a:has-text("Replace current with uploaded")').click();
-
-    await this.page.waitForLoadState('load', { timeout: 30000 });
-    await expect(this.page).toHaveURL(/overwrite=update-plugin/); 
-});
-
 When('I import data', async function (this: ICustomWorld) {
     await this.utils.importSettings('./plugin/exported_settings/wp-rocket-settings-test-2023-00-01-64e7ada0d3b70.json');
     await this.page.waitForLoadState('load', { timeout: 30000 });

--- a/src/support/steps/settings-export-import.ts
+++ b/src/support/steps/settings-export-import.ts
@@ -8,13 +8,6 @@ import { diffChecker as diffCheckerExclusions } from '../../../utils/exclusions'
 
 import { diff } from 'json-diff';
 
-
-Given('a previous version of plugin is installed', async function (this: ICustomWorld) {
-    await this.utils.uploadNewPlugin('./plugin/previous_stable.zip');
-    await this.page.waitForLoadState('load', { timeout: 30000 });
-    await expect(this.page).toHaveURL(/action=upload-plugin/); 
-});
-
 Given('I disabled all settings', async function (this: ICustomWorld) {
     await this.utils.disableAllOptions();
 });

--- a/src/support/steps/upgrading-plugin.ts
+++ b/src/support/steps/upgrading-plugin.ts
@@ -1,12 +1,5 @@
 import { ICustomWorld } from "../../common/custom-world";
-import {expect} from "@playwright/test";
 import { Given, When } from '@cucumber/cucumber';
-
-Given('plugin 3.10.9 is installed', async function (this: ICustomWorld) {
-    // Upload WPR version 3.10.9
-    await this.utils.uploadNewPlugin('./plugin/wp-rocket_3.10.9.zip');
-    await expect(this.page).toHaveURL(/action=upload-plugin/); 
-});
 
 Given('rucss beacon is opened', async function (this: ICustomWorld) {
     // Open file optimization section.
@@ -21,18 +14,6 @@ Given('rucss beacon is opened', async function (this: ICustomWorld) {
     await this.page.waitForSelector('iframe[title="Help Scout Beacon - Live Chat, Contact Form, and Knowledge Base"]');
 });
 
-When('I update to latest version', async function (this: ICustomWorld) {
-    await this.utils.uploadNewPlugin('./plugin/new_release.zip');
-    await this.page.waitForLoadState('load', { timeout: 30000 });
-    await expect(this.page).toHaveURL(/action=upload-plugin/); 
-    
-    // Replace current with uploaded
-    await this.page.locator('a:has-text("Replace current with uploaded")').click();
-
-    await this.page.waitForLoadState('load', { timeout: 30000 });
-    await expect(this.page).toHaveURL(/overwrite=update-plugin/); 
-});
-
 When('I go through rucss beacon', async function (this: ICustomWorld) {
     const iframe = this.page.frameLocator('iframe[title="Help Scout Beacon - Live Chat, Contact Form, and Knowledge Base"]');
 
@@ -43,15 +24,5 @@ When('I go through rucss beacon', async function (this: ICustomWorld) {
     await iframe.locator('#fullArticle').getByRole('link', { name: 'How to exclude files from this optimization / retain selected CSS rules' }).click();
 
     await this.utils.gotoWpr();
-    await this.page.waitForLoadState('load', { timeout: 30000 });
-});
-
-When('I downgrade to the last stable version', async function (this: ICustomWorld) {
-    await this.utils.uploadNewPlugin('./plugin/previous_stable.zip');
-    await this.page.waitForLoadState('load', { timeout: 30000 });
-    await expect(this.page).toHaveURL(/action=upload-plugin/); 
-
-    // Replace current with uploaded
-    await this.page.locator('a:has-text("Replace current with uploaded")').click();
     await this.page.waitForLoadState('load', { timeout: 30000 });
 });


### PR DESCRIPTION
## Description

Remove 3.10.9 as previous version for upgrading and checking beacon.

Fixes #31

## Type of change

*Please delete options that are not relevant.*
- Enhancement (non-breaking change which improves an existing functionality).
