### PR TITLE
Closes #55: Adds template to e2e tests

### DIFF
--- a/config/wp.config.sample.ts
+++ b/config/wp.config.sample.ts
@@ -81,11 +81,11 @@ const SCENARIO_URLS = {
 		path: '',
 		mobile: true,
 	},
-	llcssDoubleColon: {
+	doubleColon: {
 		path: 'll_bg_css_double_colon'
 	},
-	llcssSingleColon: {
-		path: 'll_bg_css_simple_colon'
+	singleColon: {
+		path: 'll_bg_css_single_colon'
 	}
 }
 

--- a/config/wp.config.sample.ts
+++ b/config/wp.config.sample.ts
@@ -81,6 +81,12 @@ const SCENARIO_URLS = {
 		path: '',
 		mobile: true,
 	},
+	llcssDoubleColon: {
+		path: 'll_bg_css_double_colon'
+	},
+	llcssSingleColon: {
+		path: 'll_bg_css_simple_colon'
+	}
 }
 
 /**

--- a/src/features/ll-css-bg-image-double-colon.feature
+++ b/src/features/ll-css-bg-image-double-colon.feature
@@ -8,7 +8,7 @@ Feature: C14626 - Should lazyload CSS background images inside internal, and ext
         And I save settings 'media' 'lazyloadCssBgImg'
 
     Scenario: Open the page template and compare to nowprocket
-        Then I must not see any visual regression 'llcssDoubleColon'
+        Then I must not see any visual regression 'doubleColon'
         Then I must not see any error in debug.log
         When I log out
         Then no error in the console different than nowprocket page 'll_bg_css_double_colon'

--- a/src/features/ll-css-bg-image-double-colon.feature
+++ b/src/features/ll-css-bg-image-double-colon.feature
@@ -1,0 +1,19 @@
+@llcssbg @setup
+Feature: C14626 - Should lazyload CSS background images inside internal, and external CSS - Double colon
+    Background:
+        Given I am logged in
+        And plugin is installed 'new_release'
+        And plugin is activated
+        When I go to 'wp-admin/options-general.php?page=wprocket#dashboard'
+        And I save settings 'media' 'lazyloadCssBgImg'
+
+    Scenario: Open the page template and compare to nowprocket
+        Then I must not see any visual regression 'llcssDoubleColon'
+        Then I must not see any error in debug.log
+        When I log out
+        Then no error in the console different than nowprocket page 'll_bg_css_double_colon'
+
+    Scenario: Inspect the element that loads the background image
+        When I log out
+        And I go to 'll_bg_css_double_colon'
+        Then I must see the correct style in the head

--- a/src/features/ll-css-bg-image-simple-colon.feature
+++ b/src/features/ll-css-bg-image-simple-colon.feature
@@ -1,0 +1,19 @@
+@llcssbg @setup
+Feature: C14626 - Should lazyload CSS background images inside internal, and external CSS - Simple colon
+    Background:
+        Given I am logged in
+        And plugin is installed 'new_release'
+        And plugin is activated
+        When I go to 'wp-admin/options-general.php?page=wprocket#dashboard'
+        And I save settings 'media' 'lazyloadCssBgImg'
+
+    Scenario: Open the page template and compare to nowprocket
+        Then I must not see any visual regression 'llcssSingleColon'
+        Then I must not see any error in debug.log
+        When I log out
+        Then no error in the console different than nowprocket page 'll_bg_css_single_colon'
+
+    Scenario: Inspect the element that loads the background image
+        When I log out
+        And I go to 'll_bg_css_single_colon'
+        Then I must see the correct style in the head

--- a/src/features/ll-css-bg-image-single-colon.feature
+++ b/src/features/ll-css-bg-image-single-colon.feature
@@ -8,7 +8,7 @@ Feature: C14626 - Should lazyload CSS background images inside internal, and ext
         And I save settings 'media' 'lazyloadCssBgImg'
 
     Scenario: Open the page template and compare to nowprocket
-        Then I must not see any visual regression 'llcssSingleColon'
+        Then I must not see any visual regression 'singleColon'
         Then I must not see any error in debug.log
         When I log out
         Then no error in the console different than nowprocket page 'll_bg_css_single_colon'

--- a/src/features/ll-css-bg-image-single-colon.feature
+++ b/src/features/ll-css-bg-image-single-colon.feature
@@ -1,5 +1,5 @@
 @llcssbg @setup
-Feature: C14626 - Should lazyload CSS background images inside internal, and external CSS - Simple colon
+Feature: C14626 - Should lazyload CSS background images inside internal, and external CSS - Single colon
     Background:
         Given I am logged in
         And plugin is installed 'new_release'


### PR DESCRIPTION
# Description

Fixes #55 

## Documentation

### User documentation

### Technical documentation

Pages https://e2e.rocketlabsqa.ovh/ll_bg_css_double_colon/ & https://e2e.rocketlabsqa.ovh/ll_bg_css_single_colon/ have been created to ensure the test are running.

## Type of change
- [x] Enhancement (non-breaking change which improves an existing functionality).
