### PR TITLE
Closes #59: Deletes or rename `debug.log` file before tests

### DIFF
--- a/src/support/hooks.ts
+++ b/src/support/hooks.ts
@@ -49,12 +49,8 @@ setDefaultTimeout(process.env.PWDEBUG ? -1 : 60 * 10000);
  * Before all tests, launches the Chromium browser.
  */
 BeforeAll(async function (this: ICustomWorld) {
-    const debugLogPath = `${WP_SSH_ROOT_DIR}wp-content/debug.log`;
-    const debugLogExists = await exists(debugLogPath);
-
-    if (debugLogExists) {
-        await rm(debugLogPath);
-    }
+    const debugLogPath = `${WP_SSH_ROOT_DIR}wp-content/*.log`;
+    await rm(debugLogPath);
 
     await deleteFolder('./backstop_data/bitmaps_test');
     browser = await chromium.launch({ headless: false });

--- a/src/support/hooks.ts
+++ b/src/support/hooks.ts
@@ -94,14 +94,6 @@ BeforeAll(async function (this: ICustomWorld) {
  * Before each test scenario without the @setup tag, performs setup tasks.
  */
 Before({tags: 'not @setup'}, async function (this: ICustomWorld) {
-    const debugLogPath = `${WP_SSH_ROOT_DIR}wp-content/debug.log`;
-    const debugLogExists = await exists(debugLogPath);
-
-    if (debugLogExists && previousScenarioName) {
-        const newDebugLogPath = `${WP_SSH_ROOT_DIR}wp-content/debug-${previousScenarioName}.log`;
-        await rename(debugLogPath, newDebugLogPath);
-    }
-
     /**
      * To uncomment during implementation of cli
      */
@@ -190,6 +182,17 @@ After(async function (this: ICustomWorld, { pickle, result }) {
 
     if (result?.status == Status.FAILED) {
         await this.utils.createScreenShot(this, pickle);
+    }
+
+    const debugLogPath = `${WP_SSH_ROOT_DIR}wp-content/debug.log`;
+    const debugLogExists = await exists(debugLogPath);
+
+    if (debugLogExists && previousScenarioName) {
+        // Close up white spaces.
+        previousScenarioName = previousScenarioName.toLowerCase();
+        previousScenarioName = previousScenarioName.replaceAll(' ', '-');
+        const newDebugLogPath = `${WP_SSH_ROOT_DIR}wp-content/debug-${previousScenarioName}.log`;
+        await rename(debugLogPath, newDebugLogPath);
     }
 
     await this.page?.close()

--- a/src/support/steps/general.ts
+++ b/src/support/steps/general.ts
@@ -18,6 +18,8 @@ import { WP_BASE_URL } from '../../../config/wp.config';
 import { createReference, compareReference } from "../../../utils/helpers";
 import type { Section } from "../../../utils/types";
 import { Page } from '@playwright/test';
+import { exists } from "../../../utils/commands";
+import { WP_SSH_ROOT_DIR } from "../../../config/wp.config";
 
 /**
  * Executes the step to log in.
@@ -230,11 +232,13 @@ Then('I should see {string}', async function (this: ICustomWorld, text) {
  * Executes the step to check for errors in debug.log.
  */
 Then('I must not see any error in debug.log', async function (this: ICustomWorld){
-    // Goto WP Rocket dashboard
-    await this.utils.gotoWpr();
-    await this.page.waitForLoadState('load', { timeout: 30000 });
-    // Assert that there is no related error in debug.log
-    await expect(this.page.locator('#wpr_debug_log_notice')).toBeHidden();
+    // Define the path to debug.log
+    const debugLogPath = `${WP_SSH_ROOT_DIR}wp-content/debug.log`;
+
+    // Check if debug.log exists
+    const debugLogExists = await exists(debugLogPath);
+
+    await expect(debugLogExists).toBe(false);
 });
 
 /**

--- a/src/support/steps/general.ts
+++ b/src/support/steps/general.ts
@@ -18,8 +18,6 @@ import { WP_BASE_URL } from '../../../config/wp.config';
 import { createReference, compareReference } from "../../../utils/helpers";
 import type { Section } from "../../../utils/types";
 import { Page } from '@playwright/test';
-import { exists } from "../../../utils/commands";
-import { WP_SSH_ROOT_DIR } from "../../../config/wp.config";
 
 /**
  * Executes the step to log in.
@@ -232,13 +230,11 @@ Then('I should see {string}', async function (this: ICustomWorld, text) {
  * Executes the step to check for errors in debug.log.
  */
 Then('I must not see any error in debug.log', async function (this: ICustomWorld){
-    // Define the path to debug.log
-    const debugLogPath = `${WP_SSH_ROOT_DIR}wp-content/debug.log`;
-
-    // Check if debug.log exists
-    const debugLogExists = await exists(debugLogPath);
-
-    await expect(debugLogExists).toBe(false);
+    // Goto WP Rocket dashboard
+    await this.utils.gotoWpr();
+    await this.page.waitForLoadState('load', { timeout: 30000 });
+    // Assert that there is no related error in debug.log
+    await expect(this.page.locator('#wpr_debug_log_notice')).toBeHidden();
 });
 
 /**

--- a/utils/commands.ts
+++ b/utils/commands.ts
@@ -155,19 +155,19 @@ export async function exists(filePath: string): Promise<boolean> {
     let command: string;
 
     if(configurations.type === ServerType.docker) {
-        command = `docker exec -T ${configurations.docker.container} test -f ${filePath}`;
+        command = `docker exec -T ${configurations.docker.container} test -f ${filePath}; echo $?`;
     } else if(configurations.type === ServerType.external) {
-        command = `ssh -i ${configurations.ssh.key} ${configurations.ssh.username}@${configurations.ssh.address} "test -f ${filePath}"`;
+        command = `ssh -i ${configurations.ssh.key} ${configurations.ssh.username}@${configurations.ssh.address} 'test -f ${filePath}; echo $?'`;
     } else {
-        command = `test -f ${filePath}`;
+        command = `test -f ${filePath}; echo $?`;
     }
 
     try {
-        await exec(command, {
+        const result = await exec(command, {
             cwd: configurations.rootDir,
             async: false
         });
-        return true;
+        return result.stdout.trim() === '0';
     } catch (error) {
         return false;
     }
@@ -222,6 +222,19 @@ export async function rm(destination: string): Promise<void> {
  */
 export async function activatePlugin(name: string): Promise<void>  {
      await wp(`plugin activate ${name}`)
+}
+
+/**
+ * Executes a SQL query on the WordPress database using WP-CLI.
+ *
+ * @function
+ * @name query
+ * @async
+ * @param {string} query - The SQL query to be executed.
+ * @returns {Promise<void>} - A Promise that resolves when the query is executed.
+ */
+export async function query(query: string): Promise<void> {
+    await wp(`db query "${query}"`)
 }
 
 /**

--- a/utils/commands.ts
+++ b/utils/commands.ts
@@ -111,6 +111,69 @@ export async function cp(origin: string, destination: string): Promise<void> {
 }
 
 /**
+ * Renames a file on the host.
+ *
+ * @function
+ * @name rename
+ * @async
+ * @param {string} oldName - The current name of the file.
+ * @param {string} newName - The new name for the file.
+ * @returns {Promise<void>} - A Promise that resolves when the rename operation is completed.
+ */
+export async function rename(oldName: string, newName: string): Promise<void> {
+    if(configurations.type === ServerType.docker) {
+        await exec(`docker exec -T ${configurations.docker.container} mv ${oldName} ${newName}`, {
+            cwd: configurations.rootDir,
+            async: false
+        });
+
+        return;
+    }
+
+    if(configurations.type === ServerType.external) {
+        console.log(`ssh -i ${configurations.ssh.key} ${configurations.ssh.username}@${configurations.ssh.address} "mv ${oldName} ${newName}"`);
+        await exec(`ssh -i ${configurations.ssh.key} ${configurations.ssh.username}@${configurations.ssh.address} "mv ${oldName} ${newName}"`);
+        return;
+    }
+
+    exec(`mv ${oldName} ${newName}`, {
+        cwd: configurations.rootDir,
+        async: false
+    });
+}
+
+/**
+ * Checks if a file exists on the server.
+ *
+ * @function
+ * @name exists
+ * @async
+ * @param {string} filePath - The path of the file to check.
+ * @returns {Promise<boolean>} - A Promise that resolves with true if the file exists, false otherwise.
+ */
+export async function exists(filePath: string): Promise<boolean> {
+    let command: string;
+
+    if(configurations.type === ServerType.docker) {
+        command = `docker exec -T ${configurations.docker.container} test -f ${filePath}`;
+    } else if(configurations.type === ServerType.external) {
+        command = `ssh -i ${configurations.ssh.key} ${configurations.ssh.username}@${configurations.ssh.address} "test -f ${filePath}"`;
+    } else {
+        command = `test -f ${filePath}`;
+    }
+
+    try {
+        await exec(command, {
+            cwd: configurations.rootDir,
+            async: false
+        });
+        return true;
+    } catch (error) {
+        return false;
+    }
+}
+
+/**
  * Unzips a compressed file to the specified destination on the server.
  *
  * @function

--- a/utils/commands.ts
+++ b/utils/commands.ts
@@ -131,7 +131,6 @@ export async function rename(oldName: string, newName: string): Promise<void> {
     }
 
     if(configurations.type === ServerType.external) {
-        console.log(`ssh -i ${configurations.ssh.key} ${configurations.ssh.username}@${configurations.ssh.address} "mv ${oldName} ${newName}"`);
         await exec(`ssh -i ${configurations.ssh.key} ${configurations.ssh.username}@${configurations.ssh.address} "mv ${oldName} ${newName}"`);
         return;
     }


### PR DESCRIPTION
# Description

Fixes #59 
## Documentation

### User documentation

It will deletes the `debug.log` before running tests, and once the test process is started, it will rename `debug.log` if it exists to `debug-{previousTestName.log`.

It requires to setup the `ssh` environment within the `wp.config.ts`  to work. 

### Technical documentation


## Type of change
*Delete options that are not relevant.*

- [x] Enhancement (non-breaking change which improves an existing functionality).

## New dependencies


## Risks


# Checklists

## Feature validation

- [x] I validated all the Acceptance Criteria. If possible, provide sreenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.

