### PR TITLE
Closes #72: Change the way we load the page for LCP

### DIFF
--- a/src/support/steps/lcp-beacon-script.ts
+++ b/src/support/steps/lcp-beacon-script.ts
@@ -52,8 +52,11 @@ Given('I visit the following urls in {string}', async function (this: ICustomWor
     for (const row of data) {
         const url: string = `${WP_BASE_URL}/${row[0]}`;
         await this.utils.visitPage(row[0]);
-        // Wait for 2 seconds before fetching from DB.
-        await this.page.waitForTimeout(2000);
+        // Wait the beacon to add an attribute `beacon-complete` to true before fetching from DB.
+        await this.page.waitForFunction(() => {
+            const beacon = document.querySelector('[data-name="wpr-lcp-beacon"]');
+            return beacon && beacon.getAttribute('beacon-completed') === 'true';
+        });
 
         // Get the LCP/ATF from the DB
         sql = `SELECT lcp, viewport FROM ${tablePrefix}wpr_above_the_fold WHERE url LIKE "%${row[0]}%"`;


### PR DESCRIPTION
# Description

Fixes #72 

## Documentation

### Technical documentation

This PR change the way we are loading the page while running test for LCP. Until now we were waiting 2 seconds before closing the page and load a new one. However, the beacon script now adds an attribute `beacon-complete` to `true` once it finishes to run. So this PR changes the 2 seconds by looking for this attribute. 

## Type of change
- [x] Enhancement (non-breaking change which improves an existing functionality).

## New dependencies

## Risks

# Checklists

## Feature validation

- [x] I validated all the Acceptance Criteria. If possible, provide sreenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.

## Documentation

- [x] I prepared the technical documentation if needed, and shared it in the PR or the GitHub issue.

## Code style
- [x] I wrote self-explanatory code about what it does.
- [x] I wrote comments to explain why it does it.
- [x] I named variables and functions explicitely.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unecessary complexity.
- [x] I listed the introduced external dependencies explicitely on the PR.
- [x] I validated the repo-specific guidelines from CONTRIBUTING.md.
