### PR TITLE
Closes #92: force-wp-mobile will not uninstall when wp-rocket is not found in cleanup hook

### DIFF
--- a/utils/page-utils.ts
+++ b/utils/page-utils.ts
@@ -535,6 +535,10 @@ export class PageUtils {
      * @return  {Promise<void>}
      */
     public cleanUp = async (): Promise<void> => {
+        // Remove helper plugin.
+        await uninstallPlugin('force-wp-mobile');
+
+        // Start the process to remove wp-rocket.
         await this.visitPage('wp-admin');
         await this.auth();
 
@@ -574,8 +578,6 @@ export class PageUtils {
         // Assert that WPR is deleted successfully
         await this.page.waitForSelector('#wp-rocket-deleted');
         await expect(this.page.locator('#wp-rocket-deleted')).toBeVisible(); 
-
-        await uninstallPlugin('force-wp-mobile');
     }
 
     /**


### PR DESCRIPTION
# Description
Fixes the issue where force-wp-mobile is not uninstalled at cleanup because of a bail out in the clean up process.

Fixes #92 

## Documentation

### User documentation

*Explain how this code impacts users.*
Moves the uninstall command to the top in the clean up process.

### Technical documentation

*Explain how this code works. Diagram & drawings are welcomed.*

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue).

## New dependencies
*List any new dependencies that are required for this change.*

## Risks
*List possible performance & security issues or risks, and explain how they have been mitigated.*

# Checklists

## Feature validation

- [ ] I validated all the Acceptance Criteria. If possible, provide sreenshots or videos.
- [ ] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [ ] I implemented built-in tests to cover the new/changed code.

## Documentation

- [ ] I prepared the user documentation for the feature/enhancement and shared it in the PR or the GitHub issue.
- [ ] The user documentation covers new/changed entry points (endpoints, WP hooks, configuration files, ...).
- [ ] I prepared the technical documentation if needed, and shared it in the PR or the GitHub issue.

## Code style
- [ ] I wrote self-explanatory code about what it does.
- [ ] I wrote comments to explain why it does it.
- [ ] I named variables and functions explicitely.
- [ ] I protected entry points against unexpected inputs.
- [ ] I did not introduce unecessary complexity.
- [ ] I listed the introduced external dependencies explicitely on the PR.
- [ ] I validated the repo-specific guidelines from CONTRIBUTING.md.

## Observability
- [ ] I handled errors when needed.
- [ ] I wrote user-facing messages that are understandable and provide actionable feedbacks.
- [ ] I prepared ways to observe the implemented system (logs, data, etc.).

## Risks
- [ ] I explicitely mentioned performance risks in the PR.
- [ ] I explicitely mentioned security risks in the PR.
