### PR TITLE
Set truthy by default on LCP/ATF test

### DIFF
--- a/src/support/steps/lcp-beacon-script.ts
+++ b/src/support/steps/lcp-beacon-script.ts
@@ -114,6 +114,9 @@ Then('lcp and atf should be as expected for {string}', async function (this: ICu
         return;
     }
 
+    // Set test status to True by default.
+    truthy = true;
+
     // Iterate over the data
     for (const key in jsonData) {
         if (Object.hasOwnProperty.call(jsonData, key) && jsonData[key].enabled === true) {


### PR DESCRIPTION
# Description

Fixes #101 

## Documentation

### User documentation

Even if tests before are failing, LCP/ATF validation against exepcted results can pass if it is all OK.


I checked that it passes correctly on trunk. I introduced an error in the expected desktop results and the test failed.