### PR TITLE
Closes #98: LCP test for checking fetchpriority fails consistently

### DIFF
--- a/src/features/lcp-beacon-image.feature
+++ b/src/features/lcp-beacon-image.feature
@@ -9,4 +9,11 @@ Feature: Fetchpriority should be applied to image
 
   Scenario: When I visited a page that has LCP with relative image
     When I log out
-    Then lcp image in 'lcp_regular_image_template' has fetchpriority
+    And I visit page 'lcp_regular_image_template' with browser dimension 1600 x 700
+    And I scroll to bottom of page
+    And I am logged in
+    And I clear cache
+    And I log out
+    And I visit page 'lcp_regular_image_template' with browser dimension 1600 x 700
+    And I scroll to bottom of page
+    Then lcp image should have fetchpriority

--- a/src/support/steps/general.ts
+++ b/src/support/steps/general.ts
@@ -239,6 +239,37 @@ When('expand mobile menu', async function (this:ICustomWorld) {
 });
 
 /**
+ * Executes the step to clear wp rocket cache.
+ */
+When('I clear cache', async function (this:ICustomWorld) {
+    // Goto WP Rocket dashboard
+    await this.utils.gotoWpr();
+
+    this.sections.set('dashboard');
+    await this.sections.toggle('clearCacheBtn');
+    await this.page.waitForLoadState('load', { timeout: 30000 });
+});
+
+/**
+ * Executes the step to visit page in a specific browser dimension.
+ */
+When('I visit page {string} with browser dimension {int} x {int}', async function (this:ICustomWorld, page, width, height) {
+    await this.page.setViewportSize({
+        width: width,
+        height: height,
+    });
+
+    await this.utils.visitPage(page);
+});
+
+/**
+ * Executes the step to scroll to the bottom of the page.
+ */
+When('I scroll to bottom of page', async function (this:ICustomWorld) {
+    await this.utils.scrollDownBottomOfAPage();
+});
+
+/**
  * Executes the step to assert the presence of specific text.
  */
 Then('I should see {string}', async function (this: ICustomWorld, text) {

--- a/src/support/steps/lcp-beacon-script.ts
+++ b/src/support/steps/lcp-beacon-script.ts
@@ -149,15 +149,8 @@ Then('lcp and atf should be as expected for {string}', async function (this: ICu
     expect(truthy).toBeTruthy();
 });
 
-Then('lcp image in {string} has fetchpriority', async function (this: ICustomWorld, page) {
-    await this.page.setViewportSize({
-        width: 1600,
-        height: 700
-    });
+Then('lcp image should have fetchpriority', async function (this: ICustomWorld) {
     truthy= false;
-
-    await this.utils.visitPage(page);
-    await this.utils.scrollDownBottomOfAPage();
 
     const imageWithFetchPriority = await this.page.evaluate(() => {
         const images = document.querySelectorAll('img');


### PR DESCRIPTION
# Description
Fixes the issue where LCP test for checking fetchpriority fails consistenly.

Fixes #98 

## Documentation

### Technical documentation

it is important to break down whole steps into small steps for easy testing and better code readability

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).

## New dependencies
None
