### PR TITLE
Wrong expected based on manual tests

### DIFF
--- a/src/support/results/expectedResultsMobile.json
+++ b/src/support/results/expectedResultsMobile.json
@@ -136,7 +136,7 @@
       "/wp-content/rocket-test-data/images/lcp/testsvg.svg"
     ],
     "viewport": [],
-    "enabled": true
+    "enabled": false
   },
   "lcp_no_dimensions_picture": {
     "lcp": [
@@ -146,7 +146,7 @@
       "/wp-content/rocket-test-data/images/lcp/testjpg.jpg",
       "/test.png"
     ],
-    "enabled": true
+    "enabled": false
   },
   "lcp_no_dimension_absolute_url": {
     "lcp": [

--- a/src/support/results/expectedResultsMobile.json
+++ b/src/support/results/expectedResultsMobile.json
@@ -146,7 +146,7 @@
       "/wp-content/rocket-test-data/images/lcp/testjpg.jpg",
       "/test.png"
     ],
-    "enabled": false
+    "enabled": true
   },
   "lcp_no_dimension_absolute_url": {
     "lcp": [


### PR DESCRIPTION
On mobile:
- lcp_no_dimension_svg: the 2nd SVG is larger hence is the LCP. The expected is wrong.

Maybe also (no removed for now):
- lcp_no_dimensions_picture: the 3rd image is slightly larger in the conditions of the Rocket-E2E mobile visit.

![image](https://github.com/wp-media/wp-rocket-e2e/assets/15233030/f52aa08e-ad78-4f2b-a3f9-e3bd3d871c98)
