### PR TITLE
Closes #114: Eradicate LCP flaky tests by increasing beacon delay

### DIFF
--- a/src/features/lcp-beacon-script.feature
+++ b/src/features/lcp-beacon-script.feature
@@ -1,4 +1,4 @@
-@lcp @setup
+@lcp @delaylcp @setup
 Feature: Beacon script captures the right images.
 
     Background:

--- a/src/support/hooks.ts
+++ b/src/support/hooks.ts
@@ -25,7 +25,7 @@ import backstop from 'backstopjs';
 import {SCENARIO_URLS, WP_SSH_ROOT_DIR,} from "../../config/wp.config";
 
 import { After, AfterAll, Before, BeforeAll, Status, setDefaultTimeout } from "@cucumber/cucumber";
-import {rename, exists, rm, testSshConnection} from "../../utils/commands";
+import {rename, exists, rm, testSshConnection, installRemotePlugin, activatePlugin, uninstallPlugin} from "../../utils/commands";
 // import {configurations, getWPDir} from "../../utils/configurations";
 
 /**
@@ -206,6 +206,22 @@ After(async function (this: ICustomWorld, { pickle, result }) {
 
     //  await resetWP();
 
+});
+
+/**
+ * Before each test scenario with the @lcp tag, performs setup tasks.
+ */
+Before({tags: '@lcp'}, async function (this: ICustomWorld) {
+    // Install and activate the remote plugin 
+    await installRemotePlugin('https://github.com/wp-media/wp-rocket-e2e-test-helper/raw/main/helper-plugin/rocket-lcp-delay.zip');
+    await activatePlugin('rocket-lcp-delay');
+});
+
+/**
+ * After each test scenario with the @lcp tag, performs teardown tasks.
+ */
+After({tags: '@lcp'}, async function (this: ICustomWorld) {
+    await uninstallPlugin('rocket-lcp-delay');
 });
 
 /**

--- a/src/support/hooks.ts
+++ b/src/support/hooks.ts
@@ -209,18 +209,18 @@ After(async function (this: ICustomWorld, { pickle, result }) {
 });
 
 /**
- * Before each test scenario with the @lcp tag, performs setup tasks.
+ * Before each test scenario with the @delaylcp tag, performs setup tasks.
  */
-Before({tags: '@lcp'}, async function (this: ICustomWorld) {
+Before({tags: '@delaylcp'}, async function (this: ICustomWorld) {
     // Install and activate the remote plugin 
     await installRemotePlugin('https://github.com/wp-media/wp-rocket-e2e-test-helper/raw/main/helper-plugin/rocket-lcp-delay.zip');
     await activatePlugin('rocket-lcp-delay');
 });
 
 /**
- * After each test scenario with the @lcp tag, performs teardown tasks.
+ * After each test scenario with the @delaylcp tag, performs teardown tasks.
  */
-After({tags: '@lcp'}, async function (this: ICustomWorld) {
+After({tags: '@delaylcp'}, async function (this: ICustomWorld) {
     await uninstallPlugin('rocket-lcp-delay');
 });
 


### PR DESCRIPTION
# Description
This PR adds a new hook to run for lcp tests which installs a helper plugin to delay lcp beacon trigger to 5000ms.

Fixes #114 

## Type of change

- [x] Enhancement (non-breaking change which improves an existing functionality).

## New dependencies
None

## Risks
None

# Checklists

## Feature validation

- [ ] I validated all the Acceptance Criteria. If possible, provide sreenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [ ] I implemented built-in tests to cover the new/changed code.


## Code style
- [x] I wrote self-explanatory code about what it does.
- [x] I wrote comments to explain why it does it.
- [ ] I named variables and functions explicitely.
- [ ] I protected entry points against unexpected inputs.
- [x] I did not introduce unecessary complexity.
- [ ] I listed the introduced external dependencies explicitely on the PR.
- [ ] I validated the repo-specific guidelines from CONTRIBUTING.md.
