### PR TITLE
Closes #88: Add LCP Templates

### DIFF
--- a/src/support/results/expectedResultsDesktop.json
+++ b/src/support/results/expectedResultsDesktop.json
@@ -248,10 +248,9 @@
       "/rocket-test-data/images/lcp/testjpeg.jpeg",
       "/rocket-test-data/images/paper.jpeg",
       "/test.png",
-      "/rocket-test-data/images/1_BDCYb3Yx8exGZVu5lLRPNw.png",
       "/rocket-test-data/images/lcp/testavif.avif"
     ],
-    "enabled": false
+    "enabled": true
   },
   "lcp_picture_template2": {
     "lcp": [
@@ -264,7 +263,7 @@
       "/rocket-test-data/images/testjpg3.jpg",
       "/rocket-test-data/images/lcp/testjpg2.jpg"
     ],
-    "enabled": false
+    "enabled": true
   },
   "lcp_bg_img_in_section": {
     "lcp": [
@@ -289,6 +288,57 @@
     ],
     "viewport": [
       "/wp-content/rocket-test-data/images/lcp/testjpg.jpg"
+    ],
+    "enabled": true
+  },
+  "lcp_bg_relative_attribute_incss": {
+    "lcp": [
+      "/wp-content/rocket-test-data/images/lcp/testavif.avif",
+      "/wp-content/rocket-test-data/images/lcp/testjpg.jpg"
+    ],
+    "viewport": [
+      "/wp-content/rocket-test-data/images/lcp/testjpeg.jpeg"
+    ],
+    "enabled": true
+  },
+  "lcp_bg_img_in_header_template": {
+    "lcp": [
+      "/wp-content/uploads/2024/03/should_be_lcp_atf_image.jpg"
+    ],
+    "viewport": [
+      "/wp-content/rocket-test-data/images/lcp/testjpg.jpg"
+    ],
+    "enabled": true
+  },
+  "lcp_6647_svgbg_template": {
+    "lcp": [],
+    "viewport": [],
+    "enabled": true
+  },
+  "lcp_6599_template2": {
+    "lcp": [
+      "https://call.adame.io/images/adaptive.php?width=200&image_url=https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/09af39a1-c481-4ad0-9283-aa4a4b6db0c9/original=true/00010-360343057.jpeg"
+    ],
+    "viewport": [
+      "https://new.rocketlabsqa.ovh/file.php?url=img.jpg",
+      "https://new.rocketlabsqa.ovh/wp-content/rocket-test-data/images/lcp/testwebp.webp"
+    ],
+    "enabled": true
+  },
+  "lcp_picture_media_type_mixed": {
+    "lcp": [
+      "https://new.rocketlabsqa.ovh/wp-content/rocket-test-data/images/lcp/istockphoto-1148323720-612x612-1-450x380.jpg"
+    ],
+    "viewport": [
+    ],
+    "enabled": true
+  },
+  "lcp_picture_relative": {
+    "lcp": [
+      "/wp-content/rocket-test-data/images/lcp/marchlarge1-scaled.jpg"
+    ],
+    "viewport": [
+      "/wp-content/rocket-test-data/images/test3.gif"
     ],
     "enabled": true
   }

--- a/src/support/results/expectedResultsDesktop.json
+++ b/src/support/results/expectedResultsDesktop.json
@@ -238,5 +238,60 @@
     ],
     "viewport": [],
     "enabled": true
+  },
+  "lcp_picture_template": {
+    "lcp": [
+      "/wp-content/rocket-test-data/images/test3.gif",
+      "/rocket-test-data/images/lcp/testjpg2.jpg",
+      "/rocket-test-data/images/testjpg3.jpg"
+    ],
+    "viewport": [
+      "/rocket-test-data/images/lcp/testwebp.webp",
+      "/rocket-test-data/images/lcp/testjpeg.jpeg",
+      "/rocket-test-data/images/paper.jpeg",
+      "/test.png",
+      "/rocket-test-data/images/1_BDCYb3Yx8exGZVu5lLRPNw.png",
+      "/rocket-test-data/images/lcp/testavif.avif"
+    ],
+    "enabled": false
+  },
+  "lcp_picture_template2": {
+    "lcp": [
+      "/rocket-test-data/images/paper.jpeg",
+      "/rocket-test-data/images/lcp/testjpeg.jpeg",
+      "/rocket-test-data/images/lcp/testwebp.webp"
+    ],
+    "viewport": [
+      "/rocket-test-data/images/test3.gif",
+      "/rocket-test-data/images/testjpg3.jpg",
+      "/rocket-test-data/images/lcp/testjpg2.jpg"
+    ],
+    "enabled": false
+  },
+  "lcp_bg_img_in_section": {
+    "lcp": [
+      "https://e2e.rocketlabsqa.ovh/wp-content/uploads/2024/03/should_be_lcp_atf_image.jpg"
+    ],
+    "viewport": [],
+    "enabled": true
+  },
+  "lcp_section_template_relative": {
+    "lcp": [
+      "/wp-content/rocket-test-data/image/test3.webp",
+      "/wp-content/rocket-test-data/image/file_example_JPG_100kB.jpg"
+    ],
+    "viewport": [
+      "/wp-content/rocket-test-data/images/lcp/testjpg.jpg"
+    ],
+    "enabled": true
+  },
+  "lcp_section_template2": {
+    "lcp": [
+      "https://images.pexels.com/photos/67636/rose-blue-flower-rose-blooms-67636.jpeg?auto=compress&cs=tinysrgb&h=350"
+    ],
+    "viewport": [
+      "/wp-content/rocket-test-data/images/lcp/testjpg.jpg"
+    ],
+    "enabled": true
   }
 }

--- a/src/support/results/expectedResultsDesktop.json
+++ b/src/support/results/expectedResultsDesktop.json
@@ -267,7 +267,7 @@
   },
   "lcp_bg_img_in_section": {
     "lcp": [
-      "https://e2e.rocketlabsqa.ovh/wp-content/uploads/2024/03/should_be_lcp_atf_image.jpg"
+      "/wp-content/uploads/2024/03/should_be_lcp_atf_image.jpg"
     ],
     "viewport": [],
     "enabled": true

--- a/src/support/results/expectedResultsMobile.json
+++ b/src/support/results/expectedResultsMobile.json
@@ -236,9 +236,12 @@
       "/rocket-test-data/images/lcp/testjpg2.jpg"
     ],
     "viewport": [
-      "/rocket-test-data/images/test3.gif",
-      "/rocket-test-data/images/testjpg3.jpg",
-      "/rocket-test-data/images/lcp/testjpg2.jpg"
+      "/rocket-test-data/images/1_BDCYb3Yx8exGZVu5lLRPNw.png",
+      "/rocket-test-data/images/lcp/testavif.avif",
+      "/test.png",
+      "/rocket-test-data/images/lcp/testwebp.webp",
+      "/rocket-test-data/images/paper.jpeg",
+      "/rocket-test-data/images/lcp/testjpeg.jpeg"
     ],
     "enabled": true
   },

--- a/src/support/results/expectedResultsMobile.json
+++ b/src/support/results/expectedResultsMobile.json
@@ -124,7 +124,7 @@
       "https://discuss-assets.s3.amazonaws.com/original/3X/1/9/19823cc1f1f887d70755e0b500dd8ce2c51ba7f9.svg"
     ],
     "viewport": [],
-    "enabled": false
+    "enabled": true
   },
   "lcp_no_dimensions_picture": {
     "lcp": [
@@ -240,7 +240,7 @@
       "/rocket-test-data/images/testjpg3.jpg",
       "/rocket-test-data/images/lcp/testjpg2.jpg"
     ],
-    "enabled": false
+    "enabled": true
   },
   "lcp_bg_img_in_section": {
     "lcp": [
@@ -265,6 +265,73 @@
     ],
     "viewport": [
       "/wp-content/rocket-test-data/images/lcp/testjpg.jpg"
+    ],
+    "enabled": true
+  },
+  "lcp_picture_template": {
+    "lcp": [
+      "/wp-content/rocket-test-data/images/test3.gif",
+      "/rocket-test-data/images/lcp/testjpg2.jpg",
+      "/rocket-test-data/images/testjpg3.jpg"
+    ],
+    "viewport": [
+      "/rocket-test-data/images/lcp/testwebp.webp",
+      "/rocket-test-data/images/lcp/testjpeg.jpeg",
+      "/rocket-test-data/images/paper.jpeg",
+      "/test.png",
+      "/rocket-test-data/images/lcp/testavif.avif"
+    ],
+    "enabled": true
+  },
+  "lcp_bg_relative_attribute_incss": {
+    "lcp": [
+      "/wp-content/rocket-test-data/images/lcp/testavif.avif",
+      "/wp-content/rocket-test-data/images/lcp/testjpg.jpg"
+    ],
+    "viewport": [
+      "/wp-content/rocket-test-data/images/lcp/testjpeg.jpeg"
+    ],
+    "enabled": true
+  },
+  "lcp_bg_img_in_header_template": {
+    "lcp": [
+      "/wp-content/uploads/2024/03/should_be_lcp_atf_image.jpg"
+    ],
+    "viewport": [
+      "/wp-content/rocket-test-data/images/lcp/testjpg.jpg"
+    ],
+    "enabled": true
+  },
+  "lcp_6647_svgbg_template": {
+    "lcp": [],
+    "viewport": [],
+    "enabled": true
+  },
+  "lcp_6599_template2": {
+    "lcp": [
+      "https://call.adame.io/images/adaptive.php?width=200&image_url=https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/09af39a1-c481-4ad0-9283-aa4a4b6db0c9/original=true/00010-360343057.jpeg"
+    ],
+    "viewport": [
+      "https://new.rocketlabsqa.ovh/file.php?url=img.jpg",
+      "https://new.rocketlabsqa.ovh/wp-content/rocket-test-data/images/lcp/testwebp.webp"
+    ],
+    "enabled": true
+  },
+  "lcp_picture_media_type_mixed": {
+    "lcp": [
+      "https://new.rocketlabsqa.ovh/wp-content/rocket-test-data/images/lcp/istockphoto-1148323720-612x612-1-450x380.jpg"
+    ],
+    "viewport": [
+    ],
+    "enabled": true
+  },
+  "lcp_picture_relative": {
+    "lcp": [
+      "/wp-content/rocket-test-data/images/test3.gif"
+    ],
+    "viewport": [
+      "/wp-content/rocket-test-data/images/lcp/marchlarge1-scaled.jpg",
+      "/wp-content/rocket-test-data/images/lcp/testwebp.webp"
     ],
     "enabled": true
   }

--- a/src/support/results/expectedResultsMobile.json
+++ b/src/support/results/expectedResultsMobile.json
@@ -244,7 +244,7 @@
   },
   "lcp_bg_img_in_section": {
     "lcp": [
-      "https://e2e.rocketlabsqa.ovh/wp-content/uploads/2024/03/should_be_lcp_atf_image.jpg"
+      "/wp-content/uploads/2024/03/should_be_lcp_atf_image.jpg"
     ],
     "viewport": [],
     "enabled": true

--- a/src/support/results/expectedResultsMobile.json
+++ b/src/support/results/expectedResultsMobile.json
@@ -240,5 +240,44 @@
     ],
     "viewport": [],
     "enabled": true
+  },
+  "lcp_picture_template2": {
+    "lcp": [
+      "/rocket-test-data/images/test3.gif",
+      "/rocket-test-data/images/testjpg3.jpg",
+      "/rocket-test-data/images/lcp/testjpg2.jpg"
+    ],
+    "viewport": [
+      "/rocket-test-data/images/test3.gif",
+      "/rocket-test-data/images/testjpg3.jpg",
+      "/rocket-test-data/images/lcp/testjpg2.jpg"
+    ],
+    "enabled": false
+  },
+  "lcp_bg_img_in_section": {
+    "lcp": [
+      "https://e2e.rocketlabsqa.ovh/wp-content/uploads/2024/03/should_be_lcp_atf_image.jpg"
+    ],
+    "viewport": [],
+    "enabled": true
+  },
+  "lcp_section_template_relative": {
+    "lcp": [
+      "/wp-content/rocket-test-data/image/test3.webp",
+      "/wp-content/rocket-test-data/image/file_example_JPG_100kB.jpg"
+    ],
+    "viewport": [
+      "/wp-content/rocket-test-data/images/lcp/testjpg.jpg"
+    ],
+    "enabled": true
+  },
+  "lcp_section_template2": {
+    "lcp": [
+      "https://images.pexels.com/photos/67636/rose-blue-flower-rose-blooms-67636.jpeg?auto=compress&cs=tinysrgb&h=350"
+    ],
+    "viewport": [
+      "/wp-content/rocket-test-data/images/lcp/testjpg.jpg"
+    ],
+    "enabled": true
   }
 }


### PR DESCRIPTION
# Description

Fixes #88 

## Documentation

### Technical documentation

This PR adds the following templates for Desktop AND Mobile: 

- lcp_bg_img_in_section
- lcp_section_template_relative
- lcp_section_template2
- lcp_picture_template
- lcp_bg_relative_attribute_incss
- lcp_bg_img_in_header_template
- lcp_6647_svgbg_template
- lcp_6599_template2
- lcp_picture_media_type_mixed
- lcp_picture_relative

## Type of change
- [x] Enhancement (non-breaking change which improves an existing functionality).

# Checklists

## Feature validation

- [x] I validated all the Acceptance Criteria. If possible, provide sreenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.