### PR TITLE
Closes #124: Adapt the LCP test for latest refactor of beacon script

### DIFF
--- a/src/support/steps/lcp-beacon-script.ts
+++ b/src/support/steps/lcp-beacon-script.ts
@@ -69,7 +69,7 @@ When('I visit the urls for {string}', async function (this: ICustomWorld, formFa
 
             // Wait the beacon to add an attribute `beacon-complete` to true before fetching from DB.
             await this.page.waitForFunction(() => {
-                const beacon = document.querySelector('[data-name="wpr-lcp-beacon"]');
+                const beacon = document.querySelector('[data-name="wpr-wpr-beacon"]');
                 return beacon && beacon.getAttribute('beacon-completed') === 'true';
             });
 


### PR DESCRIPTION
# Description
Change the reference to the container for the LCP beacon script as it got refactored and renamed.

Fixes #124 

## Documentation

### Technical documentation
Issue related to https://github.com/wp-media/wp-rocket/issues/6764
Renaming the selector to check if the beacon as finished to run or not. 

## Type of change
- [x] Enhancement (non-breaking change which improves an existing functionality).

