### PR TITLE
removed the ‘after’ property from minify_css and minify_js

### DIFF
--- a/src/common/selectors.ts
+++ b/src/common/selectors.ts
@@ -52,9 +52,6 @@ export const selectors: Selectors = {
                 type: FieldType.checkbox,
                 element: "#minify_css",
                 target: "label[for=minify_css]",
-                after: async (page: Page, state: boolean): Promise<void> => {
-                     await activateFromPopUp(page, state, "text=Activate minify CSS") 
-                }
             },
             combineCss: {
                 type: FieldType.checkbox,
@@ -92,9 +89,6 @@ export const selectors: Selectors = {
                 type: FieldType.checkbox,
                 element: "#minify_js",
                 target: "label[for=minify_js]",
-                after: async (page: Page, state: boolean): Promise<void> => {
-                    await activateFromPopUp(page, state, "text=Activate minify JavaScript") 
-               }
             },
             combineJs: {
                 type: FieldType.checkbox,


### PR DESCRIPTION
# Description

Fixes #127 

## Documentation

Since 3.16.3 for both the Minify CSS and Minify JS options, there is no additional pop-up anymore after ticking the option to validate its activation.
Solution: Removed the `after` property of elements `minify_css` and `minify_js` in `src/common/selector.ts`.

See #127 for more details