### PR TITLE
Refactor cache clear step and logout

### DIFF
--- a/src/features/lcp-beacon-image.feature
+++ b/src/features/lcp-beacon-image.feature
@@ -6,14 +6,12 @@ Feature: Fetchpriority should be applied to image
     And plugin is installed 'new_release'
     And plugin is activated
     And I go to 'wp-admin/options-general.php?page=wprocket#dashboard'
-
-  Scenario: When I visited a page that has LCP with relative image
-    When I log out
-    And I visit page 'lcp_regular_image_template' with browser dimension 1600 x 700
-    And I scroll to bottom of page
-    And I am logged in
+    And I log out
+@test
+  Scenario: Should add fetchpriority to lcp image
+    Given I visit page 'lcp_regular_image_template' with browser dimension 1600 x 700
+    When I am logged in
     And I clear cache
     And I log out
-    And I visit page 'lcp_regular_image_template' with browser dimension 1600 x 700
-    And I scroll to bottom of page
-    Then lcp image should have fetchpriority
+    Then I visit page 'lcp_regular_image_template' with browser dimension 1600 x 700
+    And lcp image should have fetchpriority

--- a/src/support/steps/general.ts
+++ b/src/support/steps/general.ts
@@ -155,7 +155,6 @@ When('I enable all settings', async function (this: ICustomWorld) {
  */
 When('I log out', async function (this: ICustomWorld) {
     await this.utils.wpAdminLogout();
-    await this.page.waitForLoadState('load', { timeout: 30000 });
 });
 
 /**

--- a/src/support/steps/general.ts
+++ b/src/support/steps/general.ts
@@ -247,7 +247,7 @@ When('I clear cache', async function (this:ICustomWorld) {
 
     this.sections.set('dashboard');
     await this.sections.toggle('clearCacheBtn');
-    await this.page.waitForLoadState('load', { timeout: 30000 });
+    await expect(this.page.getByText('WP Rocket: Cache cleared.')).toBeVisible();
 });
 
 /**

--- a/utils/page-utils.ts
+++ b/utils/page-utils.ts
@@ -283,10 +283,8 @@ export class PageUtils {
         await this.page.locator('#wp-admin-bar-my-account').hover();
         await this.page.waitForSelector('#wp-admin-bar-logout');
         await this.page.locator('#wp-admin-bar-logout a').click();
-  
-        await this.page.waitForLoadState('load', { timeout: 30000 });
-        await this.page.waitForTimeout(3000);
-    }
+        await expect(this.page.getByText('You are now logged out.')).toBeVisible();
+    }    
 
     /**
      * Performs Wordpress login action.

--- a/utils/page-utils.ts
+++ b/utils/page-utils.ts
@@ -277,9 +277,7 @@ export class PageUtils {
      * @return  {Promise<void>}
      */
     public wpAdminLogout = async (): Promise<void> => {
-        if(! await this.page.locator('#wp-admin-bar-my-account').isVisible()) {
-            return ;
-        }
+        await this.page.locator('#wp-admin-bar-my-account').isVisible();
         await this.page.locator('#wp-admin-bar-my-account').hover();
         await this.page.waitForSelector('#wp-admin-bar-logout');
         await this.page.locator('#wp-admin-bar-logout a').click();


### PR DESCRIPTION
# Description
- updated cache clear to assert the notice instead of timeout https://github.com/wp-media/wp-rocket-e2e/issues/126#issuecomment-2289044803
- removed scroll from the fetch priority feature 
- renamed the feature and re-organized steps
- removed timeout from logout and unnecessary if condition

Slack related 
https://wp-media.slack.com/archives/C05NH7JU4S2/p1723813465206409
https://wp-media.slack.com/archives/C05NH7JU4S2/p1723814326162399

Test status related to the change
![Screenshot from 2024-08-19 13-00-54](https://github.com/user-attachments/assets/785a15a7-2207-478f-895b-8b25d2af702d)


