### PR TITLE
added function for changing permalink. created performance-hints file…

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "test:llimages": "$npm_package_config_testCommand --tags @llimages",
     "test:lcp": "$npm_package_config_testCommand --tags @lcp",
     "test:test": "$npm_package_config_testCommand --tags @test",
+    "test:hints": "$npm_package_config_testCommand --tags @hints",
     "healthcheck": "ts-node healthcheck.ts",
     "wp-env": "wp-env"
   },

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "test:llimages": "$npm_package_config_testCommand --tags @llimages",
     "test:lcp": "$npm_package_config_testCommand --tags @lcp",
     "test:test": "$npm_package_config_testCommand --tags @test",
-    "test:hints": "$npm_package_config_testCommand --tags @hints",
+    "test:performancehints": "$npm_package_config_testCommand --tags @performancehints",
     "healthcheck": "ts-node healthcheck.ts",
     "wp-env": "wp-env"
   },

--- a/src/features/performance-hints.feature
+++ b/src/features/performance-hints.feature
@@ -15,16 +15,17 @@ Feature: Clear lcp/performance hints data tests
         Given performance hints data added to DB
         When permalink is changed
         Then data is removed from the performance hints tables
-
+    
     Scenario: C16390 - Should clear performance hints when switch theme
         Given performance hints data added to DB
         And switching the theme
         Then data is removed from the performance hints tables
+        And theme 'Twenty Twenty' is activated
 
     Scenario: Should clear performance hints of the current URL
         Given I log out
-        And I go to 'atf-lrc-1' desktop accepted size
-        And I go to 'atf-lrc-2' desktop accepted size
+        And I visit page 'atf-lrc-1' with browser dimension 1600 x 700
+        And I visit page 'atf-lrc-2' with browser dimension 1600 x 700
         And data for 'atf-lrc-1' present in the performance hints tables
         And data for 'atf-lrc-2' present in the performance hints tables
         Then I am logged in 
@@ -35,7 +36,7 @@ Feature: Clear lcp/performance hints data tests
     
     Scenario: C16388 - Should clear performance hints of the URL when edited
         Given I log out
-        And I go to 'atf-lrc-1' desktop accepted size
+        And I visit page 'atf-lrc-1' with browser dimension 1600 x 700
         And data for 'atf-lrc-1' present in the performance hints tables
         Then I am logged in 
         And I go to 'atf-lrc-1'
@@ -44,7 +45,7 @@ Feature: Clear lcp/performance hints data tests
 
     Scenario: C16388 - Should clear performance hints of the URL when deleted
         Given I log out
-        And I go to 'atf-lrc-1' desktop accepted size
+        And I visit page 'atf-lrc-1' with browser dimension 1600 x 700
         And data for 'atf-lrc-1' present in the performance hints tables
         Then I am logged in
         When 'atf-lrc-1' page is deleted

--- a/src/features/performance-hints.feature
+++ b/src/features/performance-hints.feature
@@ -3,51 +3,53 @@ Feature: Clear lcp/performance hints data tests
 
     Background:
         Given I am logged in
+        And I install plugin 'https://github.com/wp-media/wp-rocket-e2e-test-helper/raw/main/helper-plugin/rocket-disable-ph-saas-visit.zip'
+        And plugin 'rocket-disable-ph-saas-visit' is activated
         And plugin is installed 'new_release'
         And plugin is activated
 
     Scenario: C16387 - Should clear performance hints data when click clear PH in admin bar
-        Given performance hints data added to DB 
+        Given performance hints data added to DB
         When clear performance hints is clicked in admin bar
         Then data is removed from the performance hints tables
   
     Scenario: C16389 - Should clear performance hints when change permalinks
         Given performance hints data added to DB
-        When permalink is changed
+        When permalink structure is changed to '/%postname%'
         Then data is removed from the performance hints tables
     
     Scenario: C16390 - Should clear performance hints when switch theme
         Given performance hints data added to DB
         And switching the theme
         Then data is removed from the performance hints tables
-        And theme 'Twenty Twenty' is activated
+        Then theme 'Twenty Twenty' is activated
 
     Scenario: Should clear performance hints of the current URL
         Given I log out
-        And I visit page 'atf-lrc-1' with browser dimension 1600 x 700
-        And I visit page 'atf-lrc-2' with browser dimension 1600 x 700
+        And I visit beacon driven page 'atf-lrc-1' with browser dimension 1600 x 700
+        And I visit beacon driven page 'atf-lrc-2' with browser dimension 1600 x 700
         And data for 'atf-lrc-1' present in the performance hints tables
         And data for 'atf-lrc-2' present in the performance hints tables
-        Then I am logged in 
+        And I am logged in 
         And I go to 'atf-lrc-1'
         When clear performance hints for this URL is clicked in admin bar
         Then data for 'atf-lrc-1' is removed from the performance hints tables
-        And data for 'atf-lrc-2' present in the performance hints tables
+        Then data for 'atf-lrc-2' present in the performance hints tables
     
     Scenario: C16388 - Should clear performance hints of the URL when edited
         Given I log out
-        And I visit page 'atf-lrc-1' with browser dimension 1600 x 700
+        And I visit beacon driven page 'atf-lrc-1' with browser dimension 1600 x 700
         And data for 'atf-lrc-1' present in the performance hints tables
-        Then I am logged in 
+        And I am logged in 
         And I go to 'atf-lrc-1'
-        When I edit the content of the 'atf-lrc-1'
+        When I edit the content of post
         Then data for 'atf-lrc-1' is removed from the performance hints tables
 
     Scenario: C16388 - Should clear performance hints of the URL when deleted
         Given I log out
-        And I visit page 'atf-lrc-1' with browser dimension 1600 x 700
+        And I visit beacon driven page 'atf-lrc-1' with browser dimension 1600 x 700
         And data for 'atf-lrc-1' present in the performance hints tables
-        Then I am logged in
+        And I am logged in
         When 'atf-lrc-1' page is deleted
         Then data for 'atf-lrc-1' is removed from the performance hints tables
         Then untrash and republish 'atf-lrc-1' page

--- a/src/features/performance-hints.feature
+++ b/src/features/performance-hints.feature
@@ -3,8 +3,6 @@ Feature: Clear lcp/performance hints data tests
 
     Background:
         Given I am logged in
-        And I install plugin 'https://github.com/wp-media/wp-rocket-e2e-test-helper/raw/main/helper-plugin/rocket-disable-ph-saas-visit.zip'
-        And plugin 'rocket-disable-ph-saas-visit' is activated
         And plugin is installed 'new_release'
         And plugin is activated
 

--- a/src/features/performance-hints.feature
+++ b/src/features/performance-hints.feature
@@ -1,4 +1,4 @@
-@setup
+@setup @performancehints
 Feature: Clear lcp/performance hints data tests
 
     Background:
@@ -7,12 +7,46 @@ Feature: Clear lcp/performance hints data tests
         And plugin is activated
 
     Scenario: C16387 - Should clear performance hints data when click clear PH in admin bar
-        And performance hints data added to DB 
+        Given performance hints data added to DB 
         When clear performance hints is clicked in admin bar
         Then data is removed from the performance hints tables
-
-    @hints
-    Scenario: C16389 Should clear performance hints when change permalinks
-        And performance hints data added to DB 
+  
+    Scenario: C16389 - Should clear performance hints when change permalinks
+        Given performance hints data added to DB
         When permalink is changed
         Then data is removed from the performance hints tables
+
+    Scenario: C16390 - Should clear performance hints when switch theme
+        Given performance hints data added to DB
+        And switching the theme
+        Then data is removed from the performance hints tables
+
+    Scenario: Should clear performance hints of the current URL
+        Given I log out
+        And I go to 'atf-lrc-1' desktop accepted size
+        And I go to 'atf-lrc-2' desktop accepted size
+        And data for 'atf-lrc-1' present in the performance hints tables
+        And data for 'atf-lrc-2' present in the performance hints tables
+        Then I am logged in 
+        And I go to 'atf-lrc-1'
+        When clear performance hints for this URL is clicked in admin bar
+        Then data for 'atf-lrc-1' is removed from the performance hints tables
+        And data for 'atf-lrc-2' present in the performance hints tables
+    
+    Scenario: C16388 - Should clear performance hints of the URL when edited
+        Given I log out
+        And I go to 'atf-lrc-1' desktop accepted size
+        And data for 'atf-lrc-1' present in the performance hints tables
+        Then I am logged in 
+        And I go to 'atf-lrc-1'
+        When I edit the content of the 'atf-lrc-1'
+        Then data for 'atf-lrc-1' is removed from the performance hints tables
+
+    Scenario: C16388 - Should clear performance hints of the URL when deleted
+        Given I log out
+        And I go to 'atf-lrc-1' desktop accepted size
+        And data for 'atf-lrc-1' present in the performance hints tables
+        Then I am logged in
+        When 'atf-lrc-1' page is deleted
+        Then data for 'atf-lrc-1' is removed from the performance hints tables
+        Then untrash and republish 'atf-lrc-1' page

--- a/src/features/performance-hints.feature
+++ b/src/features/performance-hints.feature
@@ -1,0 +1,18 @@
+@setup
+Feature: Clear lcp/performance hints data tests
+
+    Background:
+        Given I am logged in
+        And plugin is installed 'new_release'
+        And plugin is activated
+
+    Scenario: C16387 - Should clear performance hints data when click clear PH in admin bar
+        And performance hints data added to DB 
+        When clear performance hints is clicked in admin bar
+        Then data is removed from the performance hints tables
+
+    @hints
+    Scenario: C16389 Should clear performance hints when change permalinks
+        And performance hints data added to DB 
+        When permalink is changed
+        Then data is removed from the performance hints tables

--- a/src/support/steps/general.ts
+++ b/src/support/steps/general.ts
@@ -111,18 +111,6 @@ When('I go to {string}', async function (this: ICustomWorld, page) {
 });
 
 /**
- * Executes the step to visit a specific page, desktop, acceptable screen-size for ATF & LRC.
- */
-When('I go to {string} desktop accepted size', async function (this: ICustomWorld, page) {
-    await this.page.setViewportSize({
-        width: 1600,
-        height: 780,
-    });
-    await this.utils.visitPage(page);
-    await this.page.waitForLoadState('load', { timeout: 100000 });
-});
-
-/**
  * Clear wpr cache
  */
 Given('clear wpr cache', async function (this: ICustomWorld) {

--- a/src/support/steps/general.ts
+++ b/src/support/steps/general.ts
@@ -111,6 +111,18 @@ When('I go to {string}', async function (this: ICustomWorld, page) {
 });
 
 /**
+ * Executes the step to visit a specific page, desktop, acceptable screen-size for ATF & LRC.
+ */
+When('I go to {string} desktop accepted size', async function (this: ICustomWorld, page) {
+    await this.page.setViewportSize({
+        width: 1600,
+        height: 780,
+    });
+    await this.utils.visitPage(page);
+    await this.page.waitForLoadState('load', { timeout: 100000 });
+});
+
+/**
  * Clear wpr cache
  */
 Given('clear wpr cache', async function (this: ICustomWorld) {

--- a/src/support/steps/general.ts
+++ b/src/support/steps/general.ts
@@ -262,10 +262,35 @@ When('I visit page {string} with browser dimension {int} x {int}', async functio
 });
 
 /**
+ * Executes the step to visit beacon driven page in a specific browser dimension.
+ */
+When('I visit beacon driven page {string} with browser dimension {int} x {int}', async function (this:ICustomWorld, page, width, height) {
+    await this.page.setViewportSize({
+        width: width,
+        height: height,
+    });
+
+    await this.utils.visitPage(page);
+
+    // Wait the beacon to add an attribute `beacon-complete` to true before fetching from DB.
+    await this.page.waitForFunction(() => {
+        const beacon = document.querySelector('[data-name="wpr-wpr-beacon"]');
+        return beacon && beacon.getAttribute('beacon-completed') === 'true';
+    });
+});
+
+/**
  * Executes the step to scroll to the bottom of the page.
  */
 When('I scroll to bottom of page', async function (this:ICustomWorld) {
     await this.utils.scrollDownBottomOfAPage();
+});
+
+/**
+ * Executes the step to change permalink structure.
+ */
+When('permalink structure is changed to {string}', async function (this: ICustomWorld, structure: string) {
+    await this.utils.permalinkChanged(structure);
 });
 
 /**

--- a/src/support/steps/performance-hints.ts
+++ b/src/support/steps/performance-hints.ts
@@ -52,7 +52,6 @@ When('clear performance hints for this URL is clicked in admin bar', async funct
     await this.page.locator('#wp-admin-bar-wp-rocket').hover();
     await this.page.waitForSelector('#wp-admin-bar-clear-performance-hints-data-url', { state: 'visible' });
     await this.page.locator('#wp-admin-bar-clear-performance-hints-data-url').click(); 
-    await this.page.waitForLoadState('load', { timeout: 30000 });
 });
 
 /*

--- a/src/support/steps/performance-hints.ts
+++ b/src/support/steps/performance-hints.ts
@@ -13,7 +13,6 @@ import { WP_BASE_URL } from '../../../config/wp.config';
 import { When, Then, Given } from '@cucumber/cucumber';
 import { dbQuery, getWPTablePrefix, getPostDataFromTitle, updatePostStatus } from "../../../utils/commands";
 import { extractFromStdout, seedData, checkData } from "../../../utils/helpers";
-import { expect } from "@playwright/test";
 
 /*
  * Executes step to add hardcoded data to DB: ATF & LRC tables

--- a/src/support/steps/performance-hints.ts
+++ b/src/support/steps/performance-hints.ts
@@ -113,6 +113,7 @@ When('clear performance hints for this URL is clicked in admin bar', async funct
     await this.page.locator('#wp-admin-bar-wp-rocket').hover();
     await this.page.waitForSelector('#wp-admin-bar-clear-performance-hints-data-url', { state: 'visible' });
     await this.page.locator('#wp-admin-bar-clear-performance-hints-data-url').click(); 
+    await this.page.waitForLoadState('load', { timeout: 30000 });
 });
 
 /*

--- a/src/support/steps/performance-hints.ts
+++ b/src/support/steps/performance-hints.ts
@@ -205,7 +205,7 @@ When('switching the theme', async function (this: ICustomWorld) {
     await this.page.locator('#wpbody-content > div.wrap > div.theme-browser.rendered > div > div:nth-child(2) > div.theme-id-container > div > a.button.activate').click(); 
 });
 
-When ('I edit the content of the {string}', async function (this: ICustomWorld, permalink: string) {
+When ('I edit the content of the {string}', async function (this: ICustomWorld) {
     await this.page.waitForSelector('#wp-admin-bar-edit', { state: 'visible' });
     await this.page.locator('#wp-admin-bar-edit').click(); 
     await this.page.waitForSelector('div.editor-header__settings > button', { state: 'visible' });

--- a/src/support/steps/performance-hints.ts
+++ b/src/support/steps/performance-hints.ts
@@ -14,9 +14,7 @@ import { dbQuery, getWPTablePrefix } from "../../../utils/commands";
 import { extractFromStdout } from "../../../utils/helpers";
 
 import {WP_BASE_URL} from "../../../config/wp.config";
-
-import assert from "assert";
-
+import { expect } from "@playwright/test";
 
 function delay(ms: number) {
     return new Promise(resolve => setTimeout(resolve, ms));
@@ -52,9 +50,8 @@ When('performance hints data added to DB', async function (this: ICustomWorld) {
 
     // Log the fetched data
     console.log('Data in the table:', resultFromStdout);
-
-    // Assert that the actual data matches the expected data
-   // assert.deepStrictEqual(resultFromStdout, expectedData, 'The data in the table does not match the expected data');
+    // Fail test if data is not in DB
+    expect (resultFromStdout).toBeTruthy();
 
 });
 
@@ -79,7 +76,8 @@ Then('data is removed from the performance hints tables', async function (this: 
         console.log('Data is removed from the table as expected.');
     } else {
         console.log('Data in the table:', resultFromStdout);
-        assert.fail('Data still exists in the table, but it was expected to be removed.');
+        // Fail test if DB results are found
+        expect (resultFromStdout).toBeFalsy();
     }
 
 });

--- a/src/support/steps/performance-hints.ts
+++ b/src/support/steps/performance-hints.ts
@@ -15,16 +15,6 @@ import { dbQuery, getWPTablePrefix, getPostDataFromTitle, updatePostStatus } fro
 import { extractFromStdout } from "../../../utils/helpers";
 import { expect } from "@playwright/test";
 
-/**
- * Gets page title from URL path.
- *
- * @param {string} path - URL Path.
- * @returns {string} - String of title from path.
- */
-const getTitleFromPath = (path: string): string => {
-    return path.replace(/-/g, ' ');
-}
-
 /*
  * Executes step to add hardcoded data to DB: ATF & LRC tables
  */ 
@@ -251,10 +241,8 @@ When ('I edit the content of post', async function (this: ICustomWorld) {
 });
 
 When ('{string} page is deleted', async function (this: ICustomWorld, permalink: string) {
-    const title = getTitleFromPath(permalink);
-
     await this.utils.gotoPages();
-    await this.page.locator('#post-search-input').fill(title);
+    await this.page.locator('#post-search-input').fill(permalink);
     await this.page.locator('#search-submit').click();
     await this.page.locator('td.title.column-title.has-row-actions.column-primary.page-title > strong > a').hover();
     await this.page.waitForSelector('div.row-actions > span.trash > a', { state: 'visible' }); 
@@ -264,8 +252,7 @@ When ('{string} page is deleted', async function (this: ICustomWorld, permalink:
 
 
 Then ('untrash and republish {string} page', async function (this: ICustomWorld, permalink: string) {
-    const title = getTitleFromPath(permalink);
-    const postDataStdout = await getPostDataFromTitle(title, 'trash', 'ID,post_title');
+    const postDataStdout = await getPostDataFromTitle(permalink, 'trash', 'ID,post_title');
     const postData = await extractFromStdout(postDataStdout);
     await updatePostStatus(parseInt(postData[0].ID, 10), 'publish');
 });

--- a/src/support/steps/performance-hints.ts
+++ b/src/support/steps/performance-hints.ts
@@ -9,79 +9,244 @@
  */
 
 import { ICustomWorld } from "../../common/custom-world";
+import { WP_BASE_URL } from '../../../config/wp.config';
 import { When, Then } from '@cucumber/cucumber';
 import { dbQuery, getWPTablePrefix } from "../../../utils/commands";
 import { extractFromStdout } from "../../../utils/helpers";
-
-import {WP_BASE_URL} from "../../../config/wp.config";
 import { expect } from "@playwright/test";
 
 function delay(ms: number) {
     return new Promise(resolve => setTimeout(resolve, ms));
 }
 
+/*
+ * Executes step to add hardcoded data to DB: ATF & LRC tables
+ */ 
 When('performance hints data added to DB', async function (this: ICustomWorld) {
     const tablePrefix = await getWPTablePrefix();
-    const tableName = `${tablePrefix}wpr_above_the_fold`;
-
-    // Truncate the table
-    await dbQuery(`TRUNCATE TABLE ${tableName}`);
+    const tableNames = [
+        `${tablePrefix}wpr_above_the_fold`,
+        `${tablePrefix}wpr_lazy_render_content`
+    ];
 
     // Define the data to be inserted
-    const expectedData = [
+    const data = [
         { url: `${WP_BASE_URL}/a`, is_mobile: 0, status: 'completed' },
         { url: `${WP_BASE_URL}/b`, is_mobile: 0, status: 'completed' },
         { url: `${WP_BASE_URL}/c`, is_mobile: 0, status: 'completed' }
     ];
 
-    // Insert new rows into the table
-    const insertSql = `
-        INSERT INTO ${tableName} (url, is_mobile, status)
-        VALUES 
-            ('${WP_BASE_URL}/a', 0, 'completed'),
-            ('${WP_BASE_URL}/b', 0, 'completed'),
-            ('${WP_BASE_URL}/c', 0, 'completed')
-    `;
-    await dbQuery(insertSql); 
+    // Build the insert SQL statement
+    const values = data.map(row => `('${row.url}', ${row.is_mobile}, '${row.status}')`).join(',');
+    const insertSql = `INSERT INTO %s (url, is_mobile, status) VALUES ${values}`;
+    const selectSql = `SELECT url, is_mobile, status FROM %s`;
 
-    // Fetch and log the data to verify
-    const selectSql = `SELECT * FROM ${tableName}`;
-    const resultFromStdout = await dbQuery(selectSql);
+    // Function to convert tabular data to array of objects
+    const parseTabularData = (tabularData) => {
+        const lines = tabularData.trim().split('\n');
+        const headers = lines.shift().split('\t');
+        return lines.map(line => {
+            const values = line.split('\t');
+            return headers.reduce((obj, header, index) => {
+                obj[header.trim()] = values[index].trim();
+                return obj;
+            }, {});
+        });
+    };
 
-    // Log the fetched data
-    console.log('Data in the table:', resultFromStdout);
-    // Fail test if data is not in DB
-    expect (resultFromStdout).toBeTruthy();
+    // Function to insert data and fetch filtered results
+    const processTable = async (tableName) => {
+        await dbQuery(`TRUNCATE TABLE ${tableName}`);
+        await dbQuery(insertSql.replace('%s', tableName));
+        
+        // Fetch the data from the table
+        const resultString = await dbQuery(selectSql.replace('%s', tableName));
+        
+        // Log the raw result to debug
+        console.log(`Raw result from ${tableName}:`, resultString);
 
+        // Convert and filter the result
+        const result = parseTabularData(resultString);
+        return result.filter(row => data.some(d => d.url === row.url && d.is_mobile === row.is_mobile && d.status === row.status));
+    };
+
+    // Process both tables and get filtered results
+    const [resultFromTable1, resultFromTable2] = await Promise.all(tableNames.map(processTable));
+
+    // Log the filtered results
+    console.log('Data in the first table:', resultFromTable1);
+    console.log('Data in the second table:', resultFromTable2);
+ 
 });
 
 When('clear performance hints is clicked in admin bar', async function (this: ICustomWorld) {
     await this.page.locator('#wp-admin-bar-wp-rocket').hover();
-    await this.page.waitForSelector('#wp-admin-bar-clean-saas', { state: 'visible' });
-    await this.page.locator('#wp-admin-bar-clean-saas').click(); 
+    await this.page.waitForSelector('#wp-admin-bar-clear-performance-hints', { state: 'visible' });
+    await this.page.locator('#wp-admin-bar-clear-performance-hints').click(); 
     await this.page.waitForSelector('div.notice.notice-success', { state: 'visible' });
 });
 
+When('clear performance hints for this URL is clicked in admin bar', async function (this: ICustomWorld) {
+    await this.page.locator('#wp-admin-bar-wp-rocket').hover();
+    await this.page.waitForSelector('#wp-admin-bar-clear-performance-hints-data-url', { state: 'visible' });
+    await this.page.locator('#wp-admin-bar-clear-performance-hints-data-url').click(); 
+});
+
+/*
+ * Executes the step to check all data has been cleared from ATF & LRC tables 
+ * (home URL ignored as its the quickest to re-appear on prewarmup)
+ */
 Then('data is removed from the performance hints tables', async function (this: ICustomWorld) {
     const tablePrefix = await getWPTablePrefix();
-    const tableName = `${tablePrefix}wpr_above_the_fold`;
+    const tables = [`${tablePrefix}wpr_above_the_fold`, `${tablePrefix}wpr_lazy_render_content`];
 
-    // Fetch and log the data to verify
-    const selectSql = `SELECT * FROM ${tableName}`;
-    const result = await dbQuery(selectSql); 
-    
-    // Extract result from stdout and log it
-    const resultFromStdout = await extractFromStdout(result);
-    if (resultFromStdout.length === 0) {
-        console.log('Data is removed from the table as expected.');
-    } else {
-        console.log('Data in the table:', resultFromStdout);
-        // Fail test if DB results are found
-        expect (resultFromStdout).toBeFalsy();
+    // Define the data to ignore based on the imported WP_BASE_URL
+    const ignoreData = [
+        { url: WP_BASE_URL, is_mobile: 1 },
+        { url: WP_BASE_URL, is_mobile: 0 }
+    ];
+
+    // Helper function to check if data is removed from a table
+    const verifyTableIsEmpty = async (tableName: string) => {
+        // Construct SQL query to select all rows
+        const selectSql = `SELECT * FROM ${tableName}`;
+        const result = await dbQuery(selectSql); 
+        const resultFromStdout = await extractFromStdout(result);
+
+        // Filter out the ignored data
+        const filteredResult = resultFromStdout.filter(row => {
+            return !ignoreData.some(ignoreEntry => 
+                row.url === ignoreEntry.url && row.is_mobile === String(ignoreEntry.is_mobile)
+            );
+        });
+
+        // Check if the filtered result is empty
+        if (filteredResult.length === 0) {
+            console.log(`Data is removed from ${tableName} as expected.`);
+        } else {
+            console.log(`Filtered data in ${tableName}:`, filteredResult);
+            expect(filteredResult).toBeFalsy();  // Fail test if filtered results are found
+        }
+    };
+
+    // Verify both tables
+    for (const table of tables) {
+        await verifyTableIsEmpty(table);
     }
 
 });
 
+/*
+ * Executes the step to check data has been cleared from ATF & LRC tables for specific URL
+ */
+Then('data for {string} is removed from the performance hints tables', async function (this: ICustomWorld, permalink: string) {
+    const tablePrefix = await getWPTablePrefix();
+    const tables = [`${tablePrefix}wpr_above_the_fold`, `${tablePrefix}wpr_lazy_render_content`];
+
+    // Helper function to check if the permalink is removed from a table
+    const verifyPermalinkRemoved = async (tableName: string) => {
+        // Construct SQL query to check if the permalink exists in the table
+        const selectSql = `SELECT * FROM ${tableName} WHERE url = '${permalink}'`;
+        const result = await dbQuery(selectSql); 
+        const resultFromStdout = await extractFromStdout(result);
+
+        // Check if any rows are returned that match the permalink
+        if (resultFromStdout.length === 0) {
+            console.log(`Permalink "${permalink}" has been successfully removed from ${tableName}.`);
+        } else {
+            console.log(`Permalink "${permalink}" still exists in ${tableName}:`, resultFromStdout);
+            expect(resultFromStdout.length).toBe(0);  // Fail test if permalink is found
+        }
+    };
+
+    // Verify both tables
+    for (const table of tables) {
+        await verifyPermalinkRemoved(table);
+    }
+});
+
+/*
+ * Executes the step to check data still exists in the ATF & LRC tables for specific URL
+ */
+Then('data for {string} present in the performance hints tables', async function (this: ICustomWorld, permalink: string) {
+    const tablePrefix = await getWPTablePrefix();
+    const tables = [`${tablePrefix}wpr_above_the_fold`, `${tablePrefix}wpr_lazy_render_content`];
+
+    // Helper function to check if the permalink still exists in a table
+    const verifyPermalinkExists = async (tableName: string) => {
+        // Construct SQL query to check if the permalink exists in the table
+        const selectSql = `SELECT * FROM ${tableName} WHERE url = '${permalink}'`;
+        const result = await dbQuery(selectSql); 
+        const resultFromStdout = await extractFromStdout(result);
+
+        // Check if any rows are returned that match the permalink
+        if (resultFromStdout.length > 0) {
+            console.log(`Permalink "${permalink}" still exists in ${tableName}.`);
+        } else {
+            console.log(`Permalink "${permalink}" does not exist in ${tableName}.`);
+            expect(resultFromStdout.length).toBeGreaterThan(0);  // Fail test if permalink is not found
+        }
+    };
+
+    // Verify both tables
+    for (const table of tables) {
+        await verifyPermalinkExists(table);
+    }
+});
+
 When('permalink is changed', async function (this: ICustomWorld) {
     await this.utils.permalinkChanged();
+});
+
+When('switching the theme', async function (this: ICustomWorld) {
+    await this.utils.gotoThemes();
+    await this.page.locator('#wpbody-content > div.wrap > div.theme-browser.rendered > div > div:nth-child(2) > div.theme-id-container').hover();
+    await this.page.waitForSelector('#wpbody-content > div.wrap > div.theme-browser.rendered > div > div:nth-child(2) > div.theme-id-container > div > a.button.activate', { state: 'visible' });
+    await this.page.locator('#wpbody-content > div.wrap > div.theme-browser.rendered > div > div:nth-child(2) > div.theme-id-container > div > a.button.activate').click(); 
+});
+
+When ('I edit the content of the {string}', async function (this: ICustomWorld, permalink: string) {
+    await this.page.waitForSelector('#wp-admin-bar-edit', { state: 'visible' });
+    await this.page.locator('#wp-admin-bar-edit').click(); 
+    await this.page.waitForSelector('div.editor-header__settings > button', { state: 'visible' });
+    await this.page.locator('div.editor-header__settings > button').click();
+});
+
+When ('{string} page is deleted', async function (this: ICustomWorld, permalink: string) {
+    await this.utils.gotoPages();
+    await this.page.locator('#post-search-input').fill(permalink);
+    await this.page.locator('#search-submit').click();
+    await this.page.locator('td.title.column-title.has-row-actions.column-primary.page-title > strong > a').hover();
+    await this.page.waitForSelector('div.row-actions > span.trash > a', { state: 'visible' }); 
+    await this.page.locator('div.row-actions > span.trash > a').click();
+    await this.page.waitForSelector('#message', { state: 'visible' }); 
+});
+
+
+Then ('untrash and republish {string} page', async function (this: ICustomWorld, permalink: string) {
+    // Go to Trashed pages and filter trashed page
+    await this.utils.gotoTrashedPages();
+    await this.page.locator('#post-search-input').fill(permalink);
+    await this.page.locator('#search-submit').click();
+    await this.page.locator('strong > span').hover();
+
+    // Untrash page
+    await this.page.waitForSelector('div.row-actions > span.untrash', { state: 'visible' }); 
+    await this.page.locator('div.row-actions > span.untrash').click();
+    await this.page.waitForSelector('#message', { state: 'visible' }); 
+
+    // Republish page
+    await this.utils.gotoPages();
+    await this.page.locator('#post-search-input').fill(permalink);
+    await this.page.locator('#search-submit').click();
+    await this.page.waitForSelector('strong > a', { state: 'visible' });
+    await this.page.locator('strong > a').hover();
+    await this.page.waitForSelector('div.row-actions > span.edit', { state: 'visible' });
+    await this.page.locator('div.row-actions > span.edit').click();
+    await this.page.waitForSelector('button.editor-post-publish-panel__toggle.editor-post-publish-button__button.is-primary.is-compact', { state: 'visible' });
+    await this.page.locator('button.editor-post-publish-panel__toggle.editor-post-publish-button__button.is-primary.is-compact').click();
+
+    // Reconfirm publish
+    await this.page.waitForSelector('div.editor-post-publish-panel__header-publish-button > button', { state: 'visible' });
+    await this.page.locator('div.editor-post-publish-panel__header-publish-button > button').click();
 });

--- a/src/support/steps/performance-hints.ts
+++ b/src/support/steps/performance-hints.ts
@@ -1,0 +1,89 @@
+/**
+ * @fileoverview
+ * This module contains Cucumber step definitions using Playwright for asserting performance hints data clearing from DB, 
+ * both ATF and LRC tables
+ * 
+ * @requires {@link ../../common/custom-world}
+ * @requires {@link @playwright/test}
+ * @requires {@link @cucumber/cucumber}
+ */
+
+import { ICustomWorld } from "../../common/custom-world";
+import { When, Then } from '@cucumber/cucumber';
+import { dbQuery, getWPTablePrefix } from "../../../utils/commands";
+import { extractFromStdout } from "../../../utils/helpers";
+
+import {WP_BASE_URL} from "../../../config/wp.config";
+
+import assert from "assert";
+
+
+function delay(ms: number) {
+    return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+When('performance hints data added to DB', async function (this: ICustomWorld) {
+    const tablePrefix = await getWPTablePrefix();
+    const tableName = `${tablePrefix}wpr_above_the_fold`;
+
+    // Truncate the table
+    await dbQuery(`TRUNCATE TABLE ${tableName}`);
+
+    // Define the data to be inserted
+    const expectedData = [
+        { url: `${WP_BASE_URL}/a`, is_mobile: 0, status: 'completed' },
+        { url: `${WP_BASE_URL}/b`, is_mobile: 0, status: 'completed' },
+        { url: `${WP_BASE_URL}/c`, is_mobile: 0, status: 'completed' }
+    ];
+
+    // Insert new rows into the table
+    const insertSql = `
+        INSERT INTO ${tableName} (url, is_mobile, status)
+        VALUES 
+            ('${WP_BASE_URL}/a', 0, 'completed'),
+            ('${WP_BASE_URL}/b', 0, 'completed'),
+            ('${WP_BASE_URL}/c', 0, 'completed')
+    `;
+    await dbQuery(insertSql); 
+
+    // Fetch and log the data to verify
+    const selectSql = `SELECT * FROM ${tableName}`;
+    const resultFromStdout = await dbQuery(selectSql);
+
+    // Log the fetched data
+    console.log('Data in the table:', resultFromStdout);
+
+    // Assert that the actual data matches the expected data
+   // assert.deepStrictEqual(resultFromStdout, expectedData, 'The data in the table does not match the expected data');
+
+});
+
+When('clear performance hints is clicked in admin bar', async function (this: ICustomWorld) {
+    await this.page.locator('#wp-admin-bar-wp-rocket').hover();
+    await this.page.waitForSelector('#wp-admin-bar-clean-saas', { state: 'visible' });
+    await this.page.locator('#wp-admin-bar-clean-saas').click(); 
+    await this.page.waitForSelector('div.notice.notice-success', { state: 'visible' });
+});
+
+Then('data is removed from the performance hints tables', async function (this: ICustomWorld) {
+    const tablePrefix = await getWPTablePrefix();
+    const tableName = `${tablePrefix}wpr_above_the_fold`;
+
+    // Fetch and log the data to verify
+    const selectSql = `SELECT * FROM ${tableName}`;
+    const result = await dbQuery(selectSql); 
+    
+    // Extract result from stdout and log it
+    const resultFromStdout = await extractFromStdout(result);
+    if (resultFromStdout.length === 0) {
+        console.log('Data is removed from the table as expected.');
+    } else {
+        console.log('Data in the table:', resultFromStdout);
+        assert.fail('Data still exists in the table, but it was expected to be removed.');
+    }
+
+});
+
+When('permalink is changed', async function (this: ICustomWorld) {
+    await this.utils.permalinkChanged();
+});

--- a/utils/commands.ts
+++ b/utils/commands.ts
@@ -455,4 +455,36 @@ export async function testSshConnection(): Promise<string> {
     }
 }
 
+/**
+ * Performs a post search action by title using wp cli.
+ *
+ * @param   {string}   title  Post Title.
+ * @param   {string}   status  Post Status.
+ * @param   {string}   fields  Post fields to return.
+ * @return  {Promise<string>}  A Promise that resolves when the post search is executed.
+ */
+export async function getPostDataFromTitle(title: string, status: string, fields: string): Promise<string> {
+    const command = wrapSSHPrefix(`wp post list --post_status=${status} --post_type=page --fields=${fields} --title='${title}'
+`);
+console.log(command);
+    const result = exec(command, { silent: true });
+
+    if (result.code === 1) {
+        return '';
+    }
+
+    return result.stdout;
+}
+
+/**
+ * Updates post status using wp cli.
+ *
+ * @param   {string}   id  Post ID.
+ * @param   {string}   status  Post Status.
+ * @return  {Promise<void>}  A Promise that resolves when the post search is executed.
+ */
+export async function updatePostStatus(id: number, status: string): Promise<void> {
+    await wp(`post update ${id} --post_status=${status}`);
+}
+
 export default wp;

--- a/utils/commands.ts
+++ b/utils/commands.ts
@@ -272,9 +272,25 @@ export async function installRemotePlugin(url: string): Promise<void>  {
  * @returns {Promise<void>} - A Promise that resolves when the uninstallation is completed.
  */
 export async function uninstallPlugin(plugin: string): Promise<void>  {
-    if(await isPluginInstalled(plugin)) {
-        await wp(`plugin uninstall --deactivate ${plugin}`);
+    const plugins = plugin.split(' ');
+    for (const p of plugins) {
+        if (await isPluginInstalled(p)) {
+            await wp(`plugin uninstall --deactivate ${p}`);
+        }
     }
+}
+
+/**
+ * Update Permalink.
+ *
+ * @function
+ * @name updatePermalinkStructure
+ * @async
+ * @param {string} structure - The permalink structure.
+ * @returns {Promise<void>} - A Promise that resolves when the permalink structure is updated.
+ */
+export async function updatePermalinkStructure(structure: string): Promise<void>  {
+    await wp(`option update permalink_structure ${structure}`);
 }
 
 /**

--- a/utils/commands.ts
+++ b/utils/commands.ts
@@ -466,7 +466,6 @@ export async function testSshConnection(): Promise<string> {
 export async function getPostDataFromTitle(title: string, status: string, fields: string): Promise<string> {
     const command = wrapSSHPrefix(`wp post list --post_status=${status} --post_type=page --fields=${fields} --title='${title}'
 `);
-console.log(command);
     const result = exec(command, { silent: true });
 
     if (result.code === 1) {

--- a/utils/page-utils.ts
+++ b/utils/page-utils.ts
@@ -189,6 +189,22 @@ export class PageUtils {
     }
 
     /**
+     * Changes permalink custom structure to have ending slash.
+     *
+     * @return  {Promise<void>}
+     */
+    public permalinkChanged = async (): Promise<void> => {
+        await this.page.goto(WP_BASE_URL + '/wp-admin/options-permalink.php');
+        await this.page.locator('#permalink_structure').fill('/%postname%/');
+
+        // Save changes.
+        await this.page.locator('#submit').click();
+
+        // Assert permalink structure successfully changed.
+        await expect(this.page.locator('#setting-error-settings_updated')).toContainText('Permalink structure updated.');
+    }
+
+    /**
      * Peforms a WPR menu dropdown action.
      *
      * @return  {Promise<void>}[return description]

--- a/utils/page-utils.ts
+++ b/utils/page-utils.ts
@@ -314,7 +314,7 @@ export class PageUtils {
         await this.page.locator('#wp-admin-bar-my-account').isVisible();
         await this.page.locator('#wp-admin-bar-my-account').hover();
         await this.page.waitForSelector('#wp-admin-bar-logout');
-        await this.page.locator('#wp-admin-bar-logout a').click();
+        await this.page.locator('#wp-admin-bar-logout > a').click();
         await expect(this.page.getByText('You are now logged out.')).toBeVisible();
     }    
 

--- a/utils/page-utils.ts
+++ b/utils/page-utils.ts
@@ -16,7 +16,7 @@ import { ICustomWorld } from '../src/common/custom-world';
 import fs from "fs/promises";
 
 import {WP_BASE_URL, WP_PASSWORD, WP_USERNAME} from '../config/wp.config';
-import { uninstallPlugin } from "./commands";
+import { uninstallPlugin, updatePermalinkStructure } from "./commands";
 
 /**
  * Utility class for interacting with a Playwright Page instance in WordPress testing.
@@ -193,15 +193,18 @@ export class PageUtils {
      *
      * @return  {Promise<void>}
      */
-    public permalinkChanged = async (): Promise<void> => {
+    public permalinkChanged = async (structure: string): Promise<void> => {
         await this.page.goto(WP_BASE_URL + '/wp-admin/options-permalink.php');
-        await this.page.locator('#permalink_structure').fill('/%postname%/');
+        const permalinkLocator = '#permalink_structure';
 
+        if (await this.page.locator(permalinkLocator).inputValue() === structure) {
+            return;
+        }
+
+        await this.page.locator(permalinkLocator).fill(structure);
         // Save changes.
         await this.page.locator('#submit').click();
-
-        // Assert permalink structure successfully changed.
-        await expect(this.page.locator('#setting-error-settings_updated')).toContainText('Permalink structure updated.');
+        await this.page.waitForSelector('text=Settings saved.', { state: 'visible' });
     }
 
     /**
@@ -311,11 +314,18 @@ export class PageUtils {
      * @return  {Promise<void>}
      */
     public wpAdminLogout = async (): Promise<void> => {
-        await this.page.locator('#wp-admin-bar-my-account').isVisible();
-        await this.page.locator('#wp-admin-bar-my-account').hover();
-        await this.page.waitForSelector('#wp-admin-bar-logout');
-        await this.page.locator('#wp-admin-bar-logout > a').click();
-        await expect(this.page.getByText('You are now logged out.')).toBeVisible();
+        // Navigate to the logout URL directly
+        await this.page.goto(WP_BASE_URL + '/wp-login.php?action=logout');
+
+        const logoutLink = this.page.getByRole('link', { name: 'log out' });
+        if (!await logoutLink.isVisible()) {
+            return;
+        }
+
+        await logoutLink.click();
+        await expect(this.page.getByText('You are now logged out.')).toBeVisible({ timeout: 10000 });
+        await this.page.goto(WP_BASE_URL + '/wp-login.php');
+        await expect(this.page.locator('#loginform')).toBeVisible();
     }    
 
     /**
@@ -566,8 +576,23 @@ export class PageUtils {
      */
     public cleanUp = async (): Promise<void> => {
         // Remove helper plugin.
-        await uninstallPlugin('force-wp-mobile');
+        await uninstallPlugin('wp-rocket force-wp-mobile rocket-disable-ph-saas-visit');
 
+        // Reset permalink structure.
+        await updatePermalinkStructure('/%postname%/'); 
+
+        // Remove WP Rocket from UI if on local run is explicitly parsed.
+        if ( process.env.npm_config_env !== undefined && process.env.npm_config_env === 'local' ) {
+            await this.removeWprViaUi();
+        }
+    }
+
+    /**
+     * Removes WP Rocket via the WP Admin UI.
+     *
+     * @return  {Promise<void>} Promise that resolves after the uninstallation process is complete.
+     */
+    public removeWprViaUi = async (): Promise<void> => {
         // Start the process to remove wp-rocket.
         await this.visitPage('wp-admin');
         await this.auth();
@@ -607,7 +632,7 @@ export class PageUtils {
 
         // Assert that WPR is deleted successfully
         await this.page.waitForSelector('#wp-rocket-deleted');
-        await expect(this.page.locator('#wp-rocket-deleted')).toBeVisible(); 
+        await expect(this.page.locator('#wp-rocket-deleted')).toBeVisible();
     }
 
     /**

--- a/utils/page-utils.ts
+++ b/utils/page-utils.ts
@@ -576,7 +576,7 @@ export class PageUtils {
      */
     public cleanUp = async (): Promise<void> => {
         // Remove helper plugin.
-        await uninstallPlugin('wp-rocket force-wp-mobile rocket-disable-ph-saas-visit');
+        await uninstallPlugin('wp-rocket force-wp-mobile');
 
         // Reset permalink structure.
         await updatePermalinkStructure('/%postname%/'); 

--- a/utils/page-utils.ts
+++ b/utils/page-utils.ts
@@ -255,6 +255,24 @@ export class PageUtils {
     }
 
     /**
+     * Navigates to Wordpress Pages page.
+     *
+     * @return  {Promise<void>}
+     */
+        public gotoPages = async (): Promise<void> => {
+            await this.page.goto(WP_BASE_URL + '/wp-admin/edit.php?post_type=page');
+        }
+
+        /**
+     * Navigates to Wordpress Pages - Trash tab.
+     *
+     * @return  {Promise<void>}
+     */
+        public gotoTrashedPages = async (): Promise<void> => {
+            await this.page.goto(WP_BASE_URL + '/wp-admin/edit.php?post_status=trash&post_type=page');
+        }
+
+    /**
      * Navigates to Wordpress site health page.
      *
      * @return  {Promise<void>}


### PR DESCRIPTION
Added function for changing permalink. created performance-hints files and added steps for 2 scenarios

# Description

Partial work on #126 

- added function for changing permalink under utils > page-utils.ts
- created performance-hints.ts & performance-hints.feature files

This commit covers:
Scenario: Should clear performance hints data when click clear PH in admin bar 
Given WPR installed and activated 
And performance hints data added to DB 
When clear performance hints is clicked in admin bar 
Then data is removed from the performance hints tables

Scenario: Should clear performance hints when change permalinks 
Given WPR installed and activated 
And performance hints data added to DB 
When permalinks is changed 
Then data is removed from the performance hints tables

Note: Scenarios still need more testing and refinement.
