### PR TITLE
Closes #146: Adds headless config

### DIFF
--- a/config/wp.config.sample.ts
+++ b/config/wp.config.sample.ts
@@ -29,6 +29,7 @@ const WP_ADMIN_USER = {
  *   WP_SSH_ADDRESS: string;
  *   WP_SSH_KEY: string;
  *   WP_SSH_ROOT_DIR: string;
+ *   ENV_HEADLESS: string;
  * }}
  */
 const {
@@ -42,7 +43,8 @@ const {
 	WP_SSH_USERNAME = '',
 	WP_SSH_ADDRESS = '',
 	WP_SSH_KEY = '',
-	WP_SSH_ROOT_DIR = ''
+	WP_SSH_ROOT_DIR = '',
+	ENV_HEADLESS = 'true'
 } = process.env;
 
 /**
@@ -104,6 +106,7 @@ const SCENARIO_URLS = {
  *   WP_SSH_ADDRESS: string;
  *   WP_SSH_KEY: string;
  *   WP_SSH_ROOT_DIR: string;
+ *   ENV_HEADLESS: boolean;
  * 	 SCENARIO_URLS: {
  * 		home: string;
  * 		llcss: string;	
@@ -124,5 +127,6 @@ export {
 	WP_SSH_ADDRESS,
 	WP_SSH_KEY,
 	WP_SSH_ROOT_DIR,
+	ENV_HEADLESS,
 	SCENARIO_URLS
 };

--- a/healthcheck.ts
+++ b/healthcheck.ts
@@ -1,7 +1,7 @@
 import chalk from "chalk";
 import wp from "./utils/commands";
 import {PageUtils} from './utils/page-utils';
-import {WP_BASE_URL} from "./config/wp.config";
+import {WP_BASE_URL, ENV_HEADLESS,} from "./config/wp.config";
 import {chromium as chrome, expect, Page} from '@playwright/test';
 import {Sections} from "./src/common/sections";
 import {selectors as pluginSelectors} from "./src/common/selectors";
@@ -36,13 +36,15 @@ async function setupBrowser(headless: boolean = false):Promise<Page> {
 }
 
 export async function openE2EPage(): Promise<void> {
-    const page = await setupBrowser(false);
+    const isHeadless = ENV_HEADLESS === 'true';
+    const page = await setupBrowser(isHeadless);
 
     await page.goto(WP_BASE_URL);
 }
 
 export async function auth(): Promise<void> {
-    const page = await setupBrowser(false);
+    const isHeadless = ENV_HEADLESS === 'true';
+    const page = await setupBrowser(isHeadless);
     const sections = new Sections(page, pluginSelectors);
     const utils = new PageUtils(page, sections);
 

--- a/src/support/hooks.ts
+++ b/src/support/hooks.ts
@@ -22,7 +22,7 @@ import { PageUtils } from "../../utils/page-utils";
 import { batchUpdateVRTestUrl } from "../../utils/helpers";
 import { deleteFolder } from "../../utils/helpers";
 import backstop from 'backstopjs';
-import {SCENARIO_URLS, WP_SSH_ROOT_DIR,} from "../../config/wp.config";
+import {SCENARIO_URLS, WP_SSH_ROOT_DIR, ENV_HEADLESS,} from "../../config/wp.config";
 
 import { After, AfterAll, Before, BeforeAll, Status, setDefaultTimeout } from "@cucumber/cucumber";
 import {rename, exists, rm, testSshConnection, installRemotePlugin, activatePlugin, uninstallPlugin} from "../../utils/commands";
@@ -56,7 +56,8 @@ BeforeAll(async function (this: ICustomWorld) {
         await rm(debugLogPath);
 
         await deleteFolder('./backstop_data/bitmaps_test');
-        browser = await chromium.launch({ headless: false });
+        const isHeadless = ENV_HEADLESS === 'true';
+        browser = await chromium.launch({ headless: isHeadless });
 
         const theme = process.env.THEME ? process.env.THEME : '';
 


### PR DESCRIPTION
# Description

Fixes #146 
This PR makes the end-to-end (e2e) tests compatible with headless mode, allowing them to be run within a Docker container. This ensures a consistent testing environment for all team members, regardless of their local setup.

## Type of change

- [x] Enhancement (non-breaking change which improves an existing functionality).

## Detailed scenario

To trigger the new code, set the `ENV_HEADLESS` environment variable to `'true'` when running the e2e tests. This will launch the Chromium browser in headless mode.

## Technical description

### Documentation

The changes in this PR involve adding a new `ENV_HEADLESS` environment variable and updating the Chromium launch configuration to use this variable. If `ENV_HEADLESS` is `'true'`, the Chromium browser is launched in headless mode. This is often used in automated testing environments.

**Don't forget to modify you config file**

### New dependencies

No new dependencies are required for this change.

### Risks

There are no known performance or security risks associated with this change.

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style
- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

# Additional Checks
- [x] In the case of complex code, I wrote comments to explain it.
- [x] When possible, I prepared ways to observe the implemented system (logs, data, etc.).
- [x] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.)