### PR TITLE
Closes #149: Update scenario urls for delayjs

### DIFF
--- a/config/scenarioUrls.json
+++ b/config/scenarioUrls.json
@@ -19,5 +19,41 @@
     "singleColon": {
       "path": "ll_bg_css_single_colon"
     }
+  },
+  "test:delayjs:genesis": {
+    "delayJs": {
+      "path": ""
+    },
+    "delayJsMobile": {
+        "path": "",
+        "mobile": true
+    }
+  },
+  "test:delayjs:flatsome": {
+    "delayJs": {
+      "path": ""
+    },
+    "delayJsMobile": {
+        "path": "",
+        "mobile": true
+    }
+  },
+  "test:delayjs:divi": {
+    "delayJs": {
+      "path": ""
+    },
+    "delayJsMobile": {
+        "path": "",
+        "mobile": true
+    }
+  },
+  "test:delayjs:astra": {
+    "delayJs": {
+      "path": ""
+    },
+    "delayJsMobile": {
+        "path": "",
+        "mobile": true
+    }
   }
 }


### PR DESCRIPTION
# Description

Fixes #149 
*Explain how this code impacts users.* This is a follow-up of this [issue](https://github.com/wp-media/wp-rocket-e2e/issues/138)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).
- [x] Enhancement (non-breaking change which improves an existing functionality).

## Detailed scenario

Running any of the following script below will trigger the references for delayjs to be created
https://github.com/wp-media/wp-rocket-e2e/blob/7b589ba20f78d9f25d0d3edaec1278cf60f92b33/package.json#L20-L23

## Technical description

### Documentation

Adds delayjs urls for backstop to create reference anytime any delayjs related test is run.

### New dependencies

N/A

### Risks

N/A

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.

## Code style
- [x] I did not introduce unnecessary complexity.