### PR TITLE
Closes #176: Backstop tests not working as expected for LLCSSBG & LRC tests when run generally

### DIFF
--- a/src/features/ll-css-bg-image-double-colon.feature
+++ b/src/features/ll-css-bg-image-double-colon.feature
@@ -8,6 +8,7 @@ Feature: C14626 - Should lazyload CSS background images inside internal, and ext
         And I save settings 'media' 'lazyloadCssBgImg'
 
     Scenario: Open the page template and compare to nowprocket
+        Given visual regression reference is generated
         Then I must not see any visual regression 'doubleColon'
         Then I must not see any error in debug.log
         When I log out

--- a/src/features/ll-css-bg-image-elementor.feature
+++ b/src/features/ll-css-bg-image-elementor.feature
@@ -2,7 +2,8 @@
 Feature: C14412 - Should be compatible with Elementor background
 
     Scenario: Enable LL BG Images and check page template
-        Given I am logged in
+        Given visual regression reference is generated
+        And I am logged in
         And plugin is installed 'new_release'
         And plugin is activated
         When I go to 'wp-admin/options-general.php?page=wprocket#dashboard'

--- a/src/features/ll-css-bg-image-fallback-js-disabled.feature
+++ b/src/features/ll-css-bg-image-fallback-js-disabled.feature
@@ -2,7 +2,8 @@
 Feature: C13977 - Should have a fallback for browsers where JavaScript is disabled
 
     Scenario: Open the page template and compare to nowprocket with javascript disabled
-        Given I am logged in
+        Given visual regression reference is generated
+        And I am logged in
         And plugin is installed 'new_release'
         And plugin is activated
         When I go to 'wp-admin/options-general.php?page=wprocket#dashboard'

--- a/src/features/ll-css-bg-image-single-colon.feature
+++ b/src/features/ll-css-bg-image-single-colon.feature
@@ -8,6 +8,7 @@ Feature: C14626 - Should lazyload CSS background images inside internal, and ext
         And I save settings 'media' 'lazyloadCssBgImg'
 
     Scenario: Open the page template and compare to nowprocket
+        Given visual regression reference is generated
         Then I must not see any visual regression 'singleColon'
         Then I must not see any error in debug.log
         When I log out

--- a/src/features/ll-css-bg-image.feature
+++ b/src/features/ll-css-bg-image.feature
@@ -8,6 +8,7 @@ Feature: C13969 - Should lazyload CSS background images inside internal, and ext
         And I save settings 'media' 'lazyloadCssBgImg'
 
     Scenario: Open the page template and compare to nowprocket
+        Given visual regression reference is generated
         Then I must not see any visual regression 'llcss'
         Then I must not see any error in debug.log
         When I log out

--- a/src/features/lrc-visual-regression.feature
+++ b/src/features/lrc-visual-regression.feature
@@ -8,6 +8,7 @@ Feature: LRC Visual Regression Test on Live Template
     And I go to 'wp-admin/options-general.php?page=wprocket#dashboard'
 
     Scenario: Shouldn't have any visual regression when visiting
+      Given visual regression reference is generated
       When I log out
       And I visit scenario urls
       And I am logged in

--- a/src/features/wpml-compatibility.feature
+++ b/src/features/wpml-compatibility.feature
@@ -12,12 +12,14 @@ Feature: C14655 - Should LL Background work on main/sub language
       And wpml directory is enabled
 
     Scenario: Open the page with directory lanaguage
+      When I log out
       Then no error in the console different than nowprocket page 'lazyload_css_background_images'
       When switch to another language
       Then I must not see any error in debug.log
 
     Scenario: Change WPML to query string option
       Given wpml query string is enabled
+      When I log out
       Then no error in the console different than nowprocket page 'lazyload_css_background_images'
       When switch to another language
       Then I must not see any error in debug.log

--- a/src/support/steps/general.ts
+++ b/src/support/steps/general.ts
@@ -117,6 +117,11 @@ Given('visual regression reference is generated', async function (this:ICustomWo
     const tags = this.pickle.tags.map(tag => tag.name);
     const tag: string = await getScenarioTag(tags);
 
+    // Bail out if there is already reference for the current tag.
+    if (process.env.scenario_tag === tag) {
+        return;
+    }
+
     try {
         await batchUpdateVRTestUrl({
             optimize: false,
@@ -131,6 +136,8 @@ Given('visual regression reference is generated', async function (this:ICustomWo
     } catch (error) {
         console.error('Backstop reference generation failed: ', error.message);
     }
+
+    process.env.scenario_tag = tag;
 });
 
 /**

--- a/src/support/steps/general.ts
+++ b/src/support/steps/general.ts
@@ -116,9 +116,14 @@ Given('theme {string} is activated', async function (this:ICustomWorld, theme) {
 Given('visual regression reference is generated', async function (this:ICustomWorld) {
     const tags = this.pickle.tags.map(tag => tag.name);
     const tag: string = await getScenarioTag(tags);
+    
+    // Array of tags to exclude from one time reference generation.
+    const exclusion = [
+        '@delayjs'
+    ]
 
     // Bail out if there is already reference for the current tag.
-    if (process.env.scenario_tag === tag) {
+    if (process.env.scenario_tag === tag && !exclusion.includes(tag)) {
         return;
     }
 


### PR DESCRIPTION
# Description
Creates backstop references for general test run.

Fixes #176 
Fixes issue with backstop test not running as expected during general test run.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).

## Detailed scenario

- Switch to develop and do a general test run (`npm run test:e2e`)

## Technical description

### Documentation

Added new step in feature files to create backstop references based on tags

### New dependencies

N/A

### Risks

N/A

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style
- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.