### PR TITLE
Closes #67: Only rename debug.log with errors relating to WPR

### DIFF
--- a/src/support/hooks.ts
+++ b/src/support/hooks.ts
@@ -19,10 +19,10 @@ import { ChromiumBrowser, chromium } from '@playwright/test';
 import { Sections } from '../common/sections';
 import { selectors as pluginSelectors } from "./../common/selectors";
 import { PageUtils } from "../../utils/page-utils";
-import { deleteFolder } from "../../utils/helpers";
+import { deleteFolder, isWprRelatedError } from "../../utils/helpers";
 import {WP_SSH_ROOT_DIR,} from "../../config/wp.config";
 import { After, AfterAll, Before, BeforeAll, Status, setDefaultTimeout } from "@cucumber/cucumber";
-import {rename, exists, rm, testSshConnection, installRemotePlugin, activatePlugin, uninstallPlugin} from "../../utils/commands";
+import {rename, exists, rm, testSshConnection, installRemotePlugin, activatePlugin, uninstallPlugin, readFile} from "../../utils/commands";
 // import {configurations, getWPDir} from "../../utils/configurations";
 
 /**
@@ -167,8 +167,10 @@ After(async function (this: ICustomWorld, { pickle, result }) {
 
     const debugLogPath = `${WP_SSH_ROOT_DIR}wp-content/debug.log`;
     const debugLogExists = await exists(debugLogPath);
+    const debugLogContents = await readFile(debugLogPath);
+    const wprRelatedError = await isWprRelatedError(debugLogContents);
 
-    if (debugLogExists && previousScenarioName) {
+    if (debugLogExists && previousScenarioName && wprRelatedError) {
         // Close up white spaces.
         previousScenarioName = previousScenarioName.toLowerCase();
         previousScenarioName = previousScenarioName.replaceAll(' ', '-');

--- a/utils/commands.ts
+++ b/utils/commands.ts
@@ -499,4 +499,25 @@ export async function updatePostStatus(id: number, status: string): Promise<void
     await wp(`post update ${id} --post_status=${status}`);
 }
 
+/**
+ * Read file on the server.
+ *
+ * @function
+ * @name readFile
+ * @async
+ * @param {string} path - The path to the file to be read.
+ * @returns {Promise<string>} - A Promise that resolves after file content is read.
+ */
+export async function readFile(path: string): Promise<string> {
+    const cwd = configurations.rootDir;
+    const command = wrapPrefix(`sudo cat ${path}`);
+    const result = exec(command, { cwd: cwd, async: false });
+
+    if (result.code !== 0) {
+        return '';
+    }
+
+    return result.stdout;
+}
+
 export default wp;

--- a/utils/helpers.ts
+++ b/utils/helpers.ts
@@ -527,8 +527,7 @@ export const getScenarioTag = async(tags: Array<string>): Promise<string> => {
 export const isWprRelatedError = async(contents: string): Promise<boolean> => {
     const patterns: Array<string> = [
         '/plugins/wp-rocket/',
-        'wpr_rucss_used_css',
-        'wpr_rocket_cache'
+        'WP_Rocket'
     ];
 
     for (const pattern of patterns) {

--- a/utils/helpers.ts
+++ b/utils/helpers.ts
@@ -516,3 +516,26 @@ export const getScenarioTag = async(tags: Array<string>): Promise<string> => {
 
     return tag;
 }
+
+/**
+ * Check for WP Rocket related error in debug.log.
+ *
+ * @param   {string}   contents  File content to be checked.
+ *
+ * @return  {Promise<boolean>}             Promise that resolves after check is completed.
+ */
+export const isWprRelatedError = async(contents: string): Promise<boolean> => {
+    const patterns: Array<string> = [
+        '/plugins/wp-rocket/',
+        'wpr_rucss_used_css',
+        'wpr_rocket_cache'
+    ];
+
+    for (const pattern of patterns) {
+        if (contents.includes(pattern)) {
+            return true;
+        }
+    }
+
+    return false;
+}


### PR DESCRIPTION
# Description

Fixes #67 
Only renames debug.log files that contain wp rocket related errors.

## Type of change

- [x] Enhancement (non-breaking change which improves an existing functionality).

## Detailed scenario
Run tests on debug.log and if a debug.log file is generated during the test run, e2e will automatically rename this log file thereby associating it to the scenario that triggered the creation even if it does not contain errors related to WP Rocket.

## Technical description

### Documentation

With this new implementation, the file is being read from the server and matched against patterns that could found when a WP Rocket error is generated.

### New dependencies

N/A

### Risks

N/A

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [ ] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [ ] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification

- This is already a test, I did not implement built-in test.
- There are no entry points
