### PR TITLE
Closes #183: Operation not permitted warning on dev latest commit

### DIFF
--- a/utils/commands.ts
+++ b/utils/commands.ts
@@ -511,7 +511,7 @@ export async function updatePostStatus(id: number, status: string): Promise<void
 export async function readFile(path: string): Promise<string> {
     const cwd = configurations.rootDir;
     const command = wrapPrefix(`sudo cat ${path}`);
-    const result = exec(command, { cwd: cwd, async: false });
+    const result = exec(command, { cwd: cwd, async: false, silent: true });
 
     if (result.code !== 0) {
         return '';


### PR DESCRIPTION
# Description

Fixes #183 
Fixes debug.log output on the command line.

## Type of change

- [x] Enhancement (non-breaking change which improves an existing functionality).

## Detailed scenario

Run any test on develop branch and see the contents of debug.log being dumped on the command line.

## Technical description

### Documentation

Since we are using the `exec` module from shelljs, the command output will be displayed by default to the command line, so by setting silent to true, the command will run silently.

### New dependencies

N/A

### Risks

N/A

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [ ] I implemented built-in tests to cover the new/changed code.

## Code style

- [ ] I wrote a self-explanatory code about what it does.
- [ ] I protected entry points against unexpected inputs.
- [ ] I did not introduce unnecessary complexity.
- [ ] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification

- No test to implement
- Just a one line change, nothing that applies to the code style checks
