### PR TITLE
Closes #216: Fix e2e triggers

### DIFF
--- a/src/support/steps/general.ts
+++ b/src/support/steps/general.ts
@@ -277,7 +277,7 @@ When('I clear cache', async function (this:ICustomWorld) {
 
     this.sections.set('dashboard');
 
-    const cacheButton = this.page.locator('p:has-text("Clear and preload all the cache files") + a').first();
+    const cacheButton = this.page.getByRole('link', { name: 'Clear and preload' });
     await cacheButton.click();
 
     await expect(this.page.getByText('WP Rocket: Cache cleared.')).toBeVisible();

--- a/src/support/steps/general.ts
+++ b/src/support/steps/general.ts
@@ -277,7 +277,7 @@ When('I clear cache', async function (this:ICustomWorld) {
 
     this.sections.set('dashboard');
 
-    const cacheButton = this.page.locator('p:has-text("This action will clear") + a').first();
+    const cacheButton = this.page.locator('p:has-text("Clear and preload all the cache files") + a').first();
     await cacheButton.click();
 
     await expect(this.page.getByText('WP Rocket: Cache cleared.')).toBeVisible();

--- a/src/support/steps/performance-hints.ts
+++ b/src/support/steps/performance-hints.ts
@@ -45,7 +45,7 @@ When('clear performance hints is clicked in admin bar', async function (this: IC
     await this.page.locator('#wp-admin-bar-wp-rocket').hover();
     await this.page.waitForSelector('#wp-admin-bar-clear-performance-hints', { state: 'visible' });
     await this.page.locator('#wp-admin-bar-clear-performance-hints').click(); 
-    await this.page.waitForSelector('text=WP Rocket: Critical images and Lazy Render data was cleared!', { state: 'visible' });
+    await this.page.waitForSelector('text=WP Rocket: Stored optimization data for Automatic Lazy Rendering, Critical Images, Preconnect to External Domains, and Preload Fonts has been cleared!', { state: 'visible' });
 });
 
 When('clear performance hints for this URL is clicked in admin bar', async function (this: ICustomWorld) {


### PR DESCRIPTION
# Description

Fixes #216 
Won't impact the user directly. However it will impact our e2e tests.

## Type of change

- [ ] New feature (non-breaking change which adds functionality).
- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] Enhancement (non-breaking change which improves an existing functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as before).
- [ ] Sub-task of #(issue number)
- [x] Chore
- [ ] Release

## Detailed scenario

### What was tested

Not tested yet

### How to test

Run E2E and check that the tests mentioned in the issue are passing.

## Technical description

### Documentation

This pull request includes updates to user-facing text in two step definitions within the test automation framework. The changes clarify the messaging displayed after specific actions are performed, improving the precision and comprehensibility of the text.


### New dependencies

NA

### Risks

NA

# Mandatory Checklist

## Code validation

- [ ] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [ ] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [ ] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification

*If some mandatory items are not relevant, explain why in this section.*

# Additional Checks
- [ ] In the case of complex code, I wrote comments to explain it.
- [ ] When possible, I prepared ways to observe the implemented system (logs, data, etc.).
- [ ] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.)