### PR TITLE
Closes #212: Enhance CPCSS feature tests and add wait for network request step

### DIFF
--- a/src/features/notice.feature
+++ b/src/features/notice.feature
@@ -19,7 +19,7 @@ Feature: CPCSS Notice
     When I have an unexpired account
     And turn on 'CPCSS'
     Then I must see the banner 'We highly recommend the updated Remove Unused CSS for a better CSS optimization. Load CSS Asynchronously is always available as a back-up.'
-    When click on 'Stay with the old option'
+    When I click on 'Stay with the old option' and wait for request 
     And refresh the page
     Then I must not see the banner 'We highly recommend the updated Remove Unused CSS for a better CSS optimization. Load CSS Asynchronously is always available as a back-up.'
     When turn on 'RUCSS'

--- a/src/support/steps/general.ts
+++ b/src/support/steps/general.ts
@@ -207,6 +207,26 @@ When('I click on {string}', async function (this: ICustomWorld, selector) {
 });
 
 /**
+ * Executes the step to click on an element with specific text and wait for network requests to complete.
+ * This step is useful when clicking triggers AJAX requests or network activity that needs to complete
+ * before proceeding to the next step.
+ * 
+ * @param {string} text - The text content of the element to click on
+ * 
+ * @remarks
+ * - Uses Playwright's text-based selector to find clickable elements
+ * - Waits for 'networkidle' state (no network requests for 500ms) after clicking
+ * - Ideal for dismiss actions, form submissions, or AJAX-heavy interactions
+ * - More reliable than simple click when network activity is expected
+ * 
+ * @see {@link https://playwright.dev/docs/api/class-page#page-wait-for-load-state|waitForLoadState}
+ */
+When('I click on {string} and wait for request', async function (this: ICustomWorld, text: string) {
+    await this.page.getByText(text).click();
+    await this.page.waitForLoadState('networkidle');
+});
+
+/**
  * Executes the step to enable all settings.
  */
 When('I enable all settings', async function (this: ICustomWorld) {


### PR DESCRIPTION
# Description

Fixes #212
Fix test `Should keep the current settings and hide notice when clicking stay with old option`

## Type of change

- [x] Chore

## Detailed scenario

### What was tested

The test itself `npm run test:cpcss`

### How to test

Run `npm run test:cpcss`

## Technical description

### Documentation

This pull request introduces improvements to the user interaction flow for clicking elements and waiting for network requests, particularly in scenarios involving AJAX-heavy interactions. The most significant changes include updating feature tests to incorporate waiting for requests and adding a new step definition in the test framework to support this functionality.

### Updates to feature tests:

* [`src/features/notice.feature`](diffhunk://#diff-0e7553b5977966deacec394e75ac892b7f5001e1f67675bfa1291eb808b23bb4L22-R22): Modified the test step for clicking on 'Stay with the old option' to include waiting for requests, ensuring the page state is stable before proceeding.

### Enhancements to test framework:

* [`src/support/steps/general.ts`](diffhunk://#diff-662fbbbcf9cc6ad24852dad65b5e70c9057cc697fbd177f5faf49fba589b8f02R209-R228): Added a new step definition `When('I click on {string} and wait for request', ...)` to handle clicks that trigger network activity, improving reliability for AJAX-heavy interactions. This step uses Playwright's `waitForLoadState('networkidle')` to ensure no network requests are pending after the click.
### New dependencies

None

### Risks

None

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.
