### PR TITLE
Closes #227: Update e2e test command to exclude @bwpsetup tag

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "lint": "eslint . --ext .ts",
     "lint:fix": "eslint  . --ext .ts --fix",
-    "test:e2e": "$npm_package_config_testCommand  --tags \"not @vr\" ; npm run push-report --tag=$npm_config_tag",
+    "test:e2e": "$npm_package_config_testCommand  --tags \"not @vr and not @bwpsetup\" ; npm run push-report --tag=$npm_config_tag",
     "test:smoke": "$npm_package_config_testCommand --tags @smoke ; npm run push-report --tag=$npm_config_tag",
     "test:local": "$npm_package_config_testCommand --tags @local",
     "test:online": "$npm_package_config_testCommand --tags @online",


### PR DESCRIPTION
# Description

Fixes #227 
When running `npm run test:e2e` it will only run WP Rocket test. 

## Type of change

- [x] Enhancement (non-breaking change which improves an existing functionality).

## Detailed scenario

### What was tested

`npm run test:e2e`

### How to test

`npm run test:e2e`

## Technical description

### Documentation

This pull request updates the `test:e2e` script in the `package.json` file to exclude additional test tags during execution.

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L13-R13): Modified the `test:e2e` script to exclude tests tagged with `@bwpsetup` in addition to `@vr`.

### New dependencies

*List any new dependencies that are required for this change.*
None

### Risks

None

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.
