### PR TITLE
Closes #79: Add check exported settings

### DIFF
--- a/src/backwpup/support/hooks.ts
+++ b/src/backwpup/support/hooks.ts
@@ -26,7 +26,7 @@ Before({tags: '@bwpupsetup'}, async function(this: ICustomWorld, {pickle}) {
 /**
  * After every test, delete data
  */
-After(async function (this: ICustomWorld) {
+After({tags: '@bwpupsetup'}, async function (this: ICustomWorld) {
     await deleteAllData(this.page);
     try {
         await testSshConnection();

--- a/src/common/selectors.ts
+++ b/src/common/selectors.ts
@@ -141,6 +141,16 @@ export const selectors: Selectors = {
                 type: FieldType.checkbox,
                 element: "#image_dimensions",
                 target: "label[for=image_dimensions]"
+            },
+            preloadfonts: {
+                type: FieldType.checkbox,
+                element: "#auto_preload_fonts",
+                target: "label[for=auto_preload_fonts]"
+            },
+            selfhostedgooglefonts: {
+                type: FieldType.checkbox,
+                element: "#host_fonts_locally",
+                target: "label[for=host_fonts_locally]"
             }
         }
     },

--- a/src/common/selectors.ts
+++ b/src/common/selectors.ts
@@ -62,15 +62,8 @@ export const selectors: Selectors = {
                     await activateFromPopUp(page, state, "text=Activate combine CSS") 
                }
             },
-            cpcss:{
-                type: FieldType.checkbox,
-                element: "#optimize_css_delivery",
-                target: "label[for=optimize_css_delivery]",
-                after: async (page: Page): Promise<void> => {
-                    await page.locator("#wpr-radio-async_css").click();
-                },
-            },
-    
+
+
             rucss:{
                 type: FieldType.checkbox,
                 element: "#optimize_css_delivery",
@@ -83,6 +76,15 @@ export const selectors: Selectors = {
                     await page.locator("text=Activate Remove Unused CSS").click();
                 }
             },
+            cpcss:{
+                type: FieldType.checkbox,
+                element: "#optimize_css_delivery",
+                target: "label[for=optimize_css_delivery]",
+                after: async (page: Page): Promise<void> => {
+                    await page.locator("#wpr-radio-async_css").click();
+                },
+            },
+    
             minifyJs: {
                 type: FieldType.checkbox,
                 element: "#minify_js",

--- a/src/features/settings-export-import.feature
+++ b/src/features/settings-export-import.feature
@@ -39,7 +39,7 @@ Feature: C2148 - Should not change the content of existing fields
         And I log in
         Then I must not see any error in debug.log
 
-    Scenario: All options are carried over after update
+    Scenario: Should not change enabled fields with update
         Given plugin is installed 'previous_stable'
         And plugin is activated
         And I enable all settings

--- a/src/features/settings-export-import.feature
+++ b/src/features/settings-export-import.feature
@@ -28,7 +28,7 @@ Feature: C2148 - Should not change the content of existing fields
         And I save settings 'media' 'lazyload'
         When I export data '3'
         Then data '3' is exported correctly
-        Then I must not see changes in exported files
+        Then Nothing changed in settings '3' compared to '2'
     
     Scenario: Visit homepage and other page
         Given plugin is installed 'new_release'
@@ -38,7 +38,7 @@ Feature: C2148 - Should not change the content of existing fields
         And I go to 'hello-world'
         And I log in
         Then I must not see any error in debug.log
-@test
+
     Scenario: Should not change enabled fields with update
         Given plugin is installed 'previous_stable'
         And plugin is activated

--- a/src/features/settings-export-import.feature
+++ b/src/features/settings-export-import.feature
@@ -38,13 +38,14 @@ Feature: C2148 - Should not change the content of existing fields
         And I go to 'hello-world'
         And I log in
         Then I must not see any error in debug.log
-
+@test
     Scenario: Should not change enabled fields with update
         Given plugin is installed 'previous_stable'
         And plugin is activated
         And I enable all settings
         And I export data '1'
         When I updated plugin to 'new_release'
+        And I go to 'wp-admin/options-general.php?page=wprocket#file_optimization'
         And I save all settings
         And I export data '2'
         Then Nothing changed in settings '2' compared to '1'

--- a/src/features/settings-export-import.feature
+++ b/src/features/settings-export-import.feature
@@ -42,7 +42,7 @@ Feature: C2148 - Should not change the content of existing fields
     Scenario: All options are carried over after update
         Given plugin is installed 'previous_stable'
         And plugin is activated
-        And I all enable settings
+        And I enable all settings
         And I export data '1'
         When I updated plugin to 'new_release'
         And I save all settings

--- a/src/features/settings-export-import.feature
+++ b/src/features/settings-export-import.feature
@@ -42,7 +42,7 @@ Feature: C2148 - Should not change the content of existing fields
     Scenario: All options are carried over after update
         Given plugin is installed 'previous_stable'
         And plugin is activated
-        And I enable settings
+        And I all enable settings
         And I export data '1'
         When I updated plugin to 'new_release'
         And I save all settings

--- a/src/features/settings-export-import.feature
+++ b/src/features/settings-export-import.feature
@@ -38,3 +38,13 @@ Feature: C2148 - Should not change the content of existing fields
         And I go to 'hello-world'
         And I log in
         Then I must not see any error in debug.log
+
+    Scenario: All options are carried over after update
+        Given plugin is installed 'previous_stable'
+        And plugin is activated
+        And I enable settings
+        And I export data '1'
+        When I updated plugin to 'new_release'
+        And I save all settings
+        And I export data '2'
+        Then Nothing changed in settings '2' compared to '1'

--- a/src/support/steps/general.ts
+++ b/src/support/steps/general.ts
@@ -89,6 +89,14 @@ Given('I save settings {string} {string}', async function (this: ICustomWorld, s
 });
 
 /**
+ * Executes the step to save all WP Rocket settings.
+ */
+Given('I save all settings', async function (this: ICustomWorld) {
+        await this.utils.saveSettings();
+});
+
+
+/**
  * Executes the step to activate the WP plugin.
  */
 Given('activate {string} plugin', async function (this: ICustomWorld, plugin) {

--- a/src/support/steps/settings-export-import.ts
+++ b/src/support/steps/settings-export-import.ts
@@ -165,25 +165,30 @@ Then('I must not see changes in exported files', async function () {
     for (const key in result) {
         if (!regex.test(key)) {
             counterCheck++;
-            foundDifferences.push(`${key}: ${JSON.stringify(result[key])}`);
+            foundDifferences.push(`"${key}": ${JSON.stringify(result[key], null, 2)}`);
         }
     }
 
-    // Log the differences for debugging
     if (counterCheck > 0) {
-        console.log('\x1b[31m%s\x1b[0m', '=== FOUND DIFFERENCES IN EXPORTED FILES ===');
-        console.log('\x1b[33m%s\x1b[0m', `Total differences found: ${counterCheck}`);
-        console.log('\x1b[33m%s\x1b[0m', 'Differences:');
-        foundDifferences.forEach((diff, index) => {
-            console.log(`  ${index + 1}. ${diff}`);
-        });
-        console.log('\x1b[33m%s\x1b[0m', '=== END DIFFERENCES ===');
-        
-        // Also log excluded fields for reference
-        console.log('\x1b[36m%s\x1b[0m', 'Excluded fields (ignored):', diffCheckerExclusions);
+        const errorMessage = `
+=== FOUND ${counterCheck} DIFFERENCES IN EXPORTED FILES ===
+
+DIFFERENCES:
+${foundDifferences.map((diff, index) => `${index + 1}. ${diff}`).join('\n')}
+
+EXCLUDED FIELDS (ignored): ${diffCheckerExclusions.join(', ')}
+
+FILE 1: ./plugin/exported_settings/wp-rocket-settings-test-2023-00-02-64e7ada0d3b70.json
+FILE 2: ./plugin/exported_settings/wp-rocket-settings-test-2023-00-03-64e7ada0d3b70.json
+
+FULL DIFF RESULT:
+${JSON.stringify(result, null, 2)}
+=== END DIFFERENCES ===`;
+
+        throw new Error(errorMessage);
     }
 
-    expect(!(counterCheck > 0), `Found ${counterCheck} differences in exported data. See console output for details.`).toBeTruthy();
+    expect(true, 'No differences found in exported data').toBeTruthy();
 });
 
 /**

--- a/src/support/steps/settings-export-import.ts
+++ b/src/support/steps/settings-export-import.ts
@@ -168,3 +168,25 @@ Then('I must not see changes in exported files', async function () {
 
     expect(!(counterCheck > 0), 'Exported data are not similar').toBeTruthy();
 });
+
+/**
+ * Executes the step to assert that nothing changed in settings between two exported files.
+ */
+Then('Nothing changed in settings {string} compared to {string}', async function (fileNo1: string, fileNo2: string) {
+    // Get exported settings data.
+    const jsonData1 = await readAnyFile(`./plugin/exported_settings/wp-rocket-settings-test-2023-00-0${fileNo2}-64e7ada0d3b70.json`);
+    const jsonData2 = await readAnyFile(`./plugin/exported_settings/wp-rocket-settings-test-2023-00-0${fileNo1}-64e7ada0d3b70.json`);
+
+    // Get excluded fields to ignore.
+    const regex = new RegExp(diffCheckerExclusions.toString().replaceAll(',', '|'));
+    const result = diff(JSON.parse(jsonData1), JSON.parse(jsonData2));  
+
+    let counterCheck = 0;
+    for (const key in result) {
+        if (! regex.test(key)) {
+            counterCheck++;
+        }
+    } 
+
+    expect(!(counterCheck > 0), `Settings changed between export '${fileNo2}' and '${fileNo1}'. Found ${counterCheck} differences.`).toBeTruthy();
+});

--- a/src/support/steps/settings-export-import.ts
+++ b/src/support/steps/settings-export-import.ts
@@ -147,49 +147,7 @@ Then('data {string} is exported correctly', async function (fileNo: string) {
     expect(validatedExportedSettings, 'Settings was not exported correctly.').toBeTruthy();
 });
 
-/**
- * Executes the step to assert that there are no changes in exported files.
- */
-Then('I must not see changes in exported files', async function () {
-    // Get exported settings data.
-    const jsonData1 = await readAnyFile('./plugin/exported_settings/wp-rocket-settings-test-2023-00-02-64e7ada0d3b70.json');
-    const jsonData2 = await readAnyFile('./plugin/exported_settings/wp-rocket-settings-test-2023-00-03-64e7ada0d3b70.json');
 
-    // Get excluded fields to ignore.
-    const regex = new RegExp(diffCheckerExclusions.toString().replaceAll(',', '|'));
-    const result = diff(JSON.parse(jsonData1), JSON.parse(jsonData2));  
-
-    let counterCheck = 0;
-    const foundDifferences: string[] = [];
-    
-    for (const key in result) {
-        if (!regex.test(key)) {
-            counterCheck++;
-            foundDifferences.push(`"${key}": ${JSON.stringify(result[key], null, 2)}`);
-        }
-    }
-
-    if (counterCheck > 0) {
-        const errorMessage = `
-=== FOUND ${counterCheck} DIFFERENCES IN EXPORTED FILES ===
-
-DIFFERENCES:
-${foundDifferences.map((diff, index) => `${index + 1}. ${diff}`).join('\n')}
-
-EXCLUDED FIELDS (ignored): ${diffCheckerExclusions.join(', ')}
-
-FILE 1: ./plugin/exported_settings/wp-rocket-settings-test-2023-00-02-64e7ada0d3b70.json
-FILE 2: ./plugin/exported_settings/wp-rocket-settings-test-2023-00-03-64e7ada0d3b70.json
-
-FULL DIFF RESULT:
-${JSON.stringify(result, null, 2)}
-=== END DIFFERENCES ===`;
-
-        throw new Error(errorMessage);
-    }
-
-    expect(true, 'No differences found in exported data').toBeTruthy();
-});
 
 /**
  * Executes the step to assert that nothing changed in settings between two exported files.

--- a/src/support/steps/settings-export-import.ts
+++ b/src/support/steps/settings-export-import.ts
@@ -160,13 +160,30 @@ Then('I must not see changes in exported files', async function () {
     const result = diff(JSON.parse(jsonData1), JSON.parse(jsonData2));  
 
     let counterCheck = 0;
+    const foundDifferences: string[] = [];
+    
     for (const key in result) {
-        if (! regex.test(key)) {
+        if (!regex.test(key)) {
             counterCheck++;
+            foundDifferences.push(`${key}: ${JSON.stringify(result[key])}`);
         }
-    } 
+    }
 
-    expect(!(counterCheck > 0), 'Exported data are not similar').toBeTruthy();
+    // Log the differences for debugging
+    if (counterCheck > 0) {
+        console.log('\x1b[31m%s\x1b[0m', '=== FOUND DIFFERENCES IN EXPORTED FILES ===');
+        console.log('\x1b[33m%s\x1b[0m', `Total differences found: ${counterCheck}`);
+        console.log('\x1b[33m%s\x1b[0m', 'Differences:');
+        foundDifferences.forEach((diff, index) => {
+            console.log(`  ${index + 1}. ${diff}`);
+        });
+        console.log('\x1b[33m%s\x1b[0m', '=== END DIFFERENCES ===');
+        
+        // Also log excluded fields for reference
+        console.log('\x1b[36m%s\x1b[0m', 'Excluded fields (ignored):', diffCheckerExclusions);
+    }
+
+    expect(!(counterCheck > 0), `Found ${counterCheck} differences in exported data. See console output for details.`).toBeTruthy();
 });
 
 /**


### PR DESCRIPTION
# Description

Fixes #79 
It adds a check if old exported settings === new exported settings.

## Type of change

- [x] Enhancement (non-breaking change which improves an existing functionality).

## Detailed scenario

### What was tested

`npm run test:smoke` 

### How to test

`npm run test:smoke`

## Technical description

### Documentation

This pull request introduces enhancements to the settings export-import feature, ensuring that plugin updates do not alter existing settings. The changes include adding a new scenario to validate settings consistency, implementing new step definitions for saving and validating settings, and improving the error reporting for differences in exported files.

### Feature Enhancements:
* **New Scenario for Settings Consistency**: Added a test scenario in `src/features/settings-export-import.feature` to verify that all settings remain unchanged after a plugin update.

### Step Definition Updates:
* **Save Settings Step**: Added a new step definition in `src/support/steps/general.ts` to save all WP Rocket settings programmatically.
* **Validate Exported Settings**: Enhanced the step definition in `src/support/steps/settings-export-import.ts` to assert that no differences exist between two exported settings files, with detailed error reporting for found differences.

### New dependencies

None

### Risks

None

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.


## Screenshot
Test happened between `3.17.1` & `3.19.0.1` so expected differences happens and fail the test.
![Screenshot 2025-06-25 at 02 20 53](https://github.com/user-attachments/assets/8d7cdb26-b628-4b96-a7be-1a89c8daa645)
