### PR TITLE
Exclude delayjs test from general run

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "lint": "eslint . --ext .ts",
     "lint:fix": "eslint  . --ext .ts --fix",
-    "test:e2e": "$npm_package_config_testCommand  --tags \"not @vr and not @bwpsetup and not @bwpupsmoke\" ; npm run push-report --tag=$npm_config_tag",
+    "test:e2e": "$npm_package_config_testCommand  --tags \"not @vr and not @delayjs and not @bwpupsmoke\" ; npm run push-report --tag=$npm_config_tag",
     "test:smoke": "$npm_package_config_testCommand --tags @smoke ; npm run push-report --tag=$npm_config_tag",
     "test:local": "$npm_package_config_testCommand --tags @local",
     "test:export": "$npm_package_config_testCommand --tags @export",
@@ -29,7 +29,7 @@
     "push-report": "ts-node report.ts",
     "wp-env": "wp-env",
     "test:bwpuponboarding": "$npm_package_config_testCommand --tags @bwpuponboarding",
-    "test:bwpupsmoke": "$npm_package_config_testCommand --tags @bwupsmoke ; npm run open-report",
+    "test:bwpupsmoke": "$npm_package_config_testCommand --tags @bwpupsmoke ; npm run open-report",
     "open-report": "ts-node open-report.ts"
   },
   "repository": {

--- a/src/backwpup/features/backup.feature
+++ b/src/backwpup/features/backup.feature
@@ -1,4 +1,4 @@
-@bwupsetup @bwupsmoke
+@bwupsetup @bwpupsmoke
 Feature: Should be able to backup
 
   Background:

--- a/src/backwpup/features/delete-plugin.feature
+++ b/src/backwpup/features/delete-plugin.feature
@@ -1,4 +1,4 @@
-@bwpsetup @bwpplugindeletion @bwupsmoke
+@bwpsetup @bwpplugindeletion @bwpupsmoke
 Feature: Should successfully delete BackWPup plugin
 
     Background:

--- a/src/backwpup/features/onboarding.feature
+++ b/src/backwpup/features/onboarding.feature
@@ -1,4 +1,4 @@
-@bwupsetup @bwpuponboarding @bwupsmoke
+@bwupsetup @bwpupsmoke
 Feature: BackWpUp Onboarding
 
   Background:


### PR DESCRIPTION
# Description

Temporarily excludes delayjs test from general run and also updated backwpup tag to be correctly excluded from general test run.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).
- [x] Enhancement (non-breaking change which improves an existing functionality).

## Detailed scenario

### What was tested

delayjs test and backwpup test don't run with general test run.

### How to test

- Run general test
- See that delayjs and backwpup test don't run

## Technical description

### Documentation

Excluded delayjs test from general test run and use correct backwpup tag for proper exclusion from general test run.

### New dependencies

N/A

### Risks

N/A

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [ ] I implemented built-in tests to cover the new/changed code.

## Code style

- [ ] I wrote a self-explanatory code about what it does.
- [ ] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [ ] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification

Not applicable to the changes in this PR.

# Additional Checks
- [ ] In the case of complex code, I wrote comments to explain it.
- [ ] When possible, I prepared ways to observe the implemented system (logs, data, etc.).
- [ ] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.)
