### PR TITLE
Add retry for flaky tests and temporarily skip backstop VR steps

### DIFF
--- a/cucumber.json
+++ b/cucumber.json
@@ -24,7 +24,8 @@
       "json:test-results/cucumber-report.json",
       "rerun:@rerun.txt"
     ],
-    "parallel": 1
+    "parallel": 1,
+    "retry": 3
   },
   "rerun": {
     "formatOptions": {

--- a/src/support/steps/general.ts
+++ b/src/support/steps/general.ts
@@ -115,6 +115,7 @@ Given('theme {string} is activated', async function (this:ICustomWorld, theme) {
  * Executes the step to generate visual regression reference via backstopjs.
  */
 Given('visual regression reference is generated', async function (this:ICustomWorld) {
+    return; // Skip VR tests.
     const tags = this.pickle.tags.map(tag => tag.name);
     const tag: string = await getScenarioTag(tags);
     
@@ -412,6 +413,7 @@ Then('clean up', async function (this: ICustomWorld) {
  * Executes the step to check for visual regression.
  */
 Then('I must not see any visual regression {string}', async function (this: ICustomWorld, label: string) {
+    return; // Skip VR tests.
     await compareReference(label);
 });
 
@@ -419,6 +421,7 @@ Then('I must not see any visual regression {string}', async function (this: ICus
  * Executes the step to check for LRC visual regression.
  */
 Then('I must not see any visual regression in scenario urls', async function (this: ICustomWorld) {
+    return; // Skip VR tests.
     const tags = this.pickle.tags.map(tag => tag.name);
     const tag: string = await getScenarioTag(tags);
     const liveUrl = scenarioUrls[tag];


### PR DESCRIPTION
# Description

Added retry for flaky tests and temporarily skip bakstop VR steps.

## Type of change

- [x] Enhancement (non-breaking change which improves an existing functionality).

## Detailed scenario

### What was tested

Run tests and see that flaky tests are retried automatically and backstop VR steps are skipped.

### How to test

Same as what was tested.

## Technical description

### Documentation

- Added the retry option to the cucmber config (cucumber.json). Will retry flaky tests when failed up to 3x before asserting as failed
- Temporarily skipped backstop VR steps by adding an unconditional `return` for related step definition.

### New dependencies

N/A

### Risks

Backstop VR tests will not run, this is a risk we are willing to take now since, the backstop test report don't even appear in the general cucumber report at the moment. We'll look into how we can make backstop tests more compatible with cucumber test run [here](https://github.com/wp-media/wp-rocket-e2e/issues/249)

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [ ] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [ ] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [ ] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification

Not applicable to the changes in this PR.

# Additional Checks
- [ ] In the case of complex code, I wrote comments to explain it.
- [ ] When possible, I prepared ways to observe the implemented system (logs, data, etc.).
- [ ] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.)
