### PR TITLE
Closes #1011 - Setup FTP storage and create backup

### DIFF
--- a/config/wp.config.sample.ts
+++ b/config/wp.config.sample.ts
@@ -29,9 +29,11 @@ const IMAGIFY_INFOS = {
  * Backwpup settings information
  */
 const BACKWPUP_INFOS = {
-	msAccountName: '',
-	msAccessKey: '',
-	msContainer: ''
+    msazure: {
+        accountName: '',
+        accessKey: '',
+        container: ''
+    }
 } as const;
 
 /**

--- a/config/wp.config.sample.ts
+++ b/config/wp.config.sample.ts
@@ -33,6 +33,12 @@ const BACKWPUP_INFOS = {
         accountName: '',
         accessKey: '',
         container: ''
+    },
+    ftp: {
+        host: '',
+        username: '',
+        password: '',
+        port: '21'
     }
 } as const;
 

--- a/config/wp.config.sample.ts
+++ b/config/wp.config.sample.ts
@@ -38,7 +38,9 @@ const BACKWPUP_INFOS = {
         host: '',
         username: '',
         password: '',
-        port: '21'
+        port: '21',
+        ssl: false,
+        passiveMode: true
     }
 } as const;
 

--- a/src/backwpup/features/storages/ftp.feature
+++ b/src/backwpup/features/storages/ftp.feature
@@ -1,0 +1,19 @@
+@bwupsetup @bwpupstorage @bwpupsmoke @bwpupstorageftp
+
+Feature: Should be able to work with FTP storage
+
+  Scenario: Setup FTP
+    Given I am logged in
+    And I delete backwpup plugin
+    And plugin is installed 'backwpup-pro'
+    And plugin is activated
+    And I go '/wp-admin/admin.php?page=backwpup'
+    When I click '.js-backwpup-onboarding-step-2' button to continue
+    And I click '.js-backwpup-onboarding-step-3' button to continue
+    When I Configure web server storage
+    And I go '/wp-admin/admin.php?page=backwpup'
+    Then I should see 'mixed' job cards
+    And I set up 'ftp' storage
+    Then 'ftp' storage should be selected
+    When I click on manual backup of a job
+    Then '2' backup is generated and added to history

--- a/src/backwpup/features/storages/ftp.feature
+++ b/src/backwpup/features/storages/ftp.feature
@@ -2,6 +2,20 @@
 
 Feature: Should be able to work with FTP storage
 
+  Scenario: Setup FTP in Onboarding
+    Given I am logged in
+    And I delete backwpup plugin
+    And plugin is installed 'backwpup-pro'
+    And plugin is activated
+    And I go '/wp-admin/admin.php?page=backwpup'
+    When I click '.js-backwpup-onboarding-step-2' button to continue
+    And I click '.js-backwpup-onboarding-step-3' button to continue
+    When I set up 'ftp' storage for first backup
+    Then 'ftp' storage should be selected for first backup
+    Then I save and submit the onboarding form
+    And I go '/wp-admin/admin.php?page=backwpup'
+    Then I should see 'mixed' job cards
+
   Scenario: Setup FTP
     Given I am logged in
     And I delete backwpup plugin

--- a/src/backwpup/features/storages/ftp.feature
+++ b/src/backwpup/features/storages/ftp.feature
@@ -1,8 +1,7 @@
 @bwupsetup @bwpupstorage @bwpupsmoke @bwpupstorageftp
 
 Feature: Should be able to work with FTP storage
-
-  Scenario: Setup FTP in Onboarding
+  Background:
     Given I am logged in
     And I delete backwpup plugin
     And plugin is installed 'backwpup-pro'
@@ -10,20 +9,15 @@ Feature: Should be able to work with FTP storage
     And I go '/wp-admin/admin.php?page=backwpup'
     When I click '.js-backwpup-onboarding-step-2' button to continue
     And I click '.js-backwpup-onboarding-step-3' button to continue
+
+  Scenario: Setup FTP in Onboarding
     When I set up 'ftp' storage for first backup
     Then 'ftp' storage should be selected for first backup
     Then I save and submit the onboarding form
     And I go '/wp-admin/admin.php?page=backwpup'
     Then I should see 'mixed' job cards
 
-  Scenario: Setup FTP
-    Given I am logged in
-    And I delete backwpup plugin
-    And plugin is installed 'backwpup-pro'
-    And plugin is activated
-    And I go '/wp-admin/admin.php?page=backwpup'
-    When I click '.js-backwpup-onboarding-step-2' button to continue
-    And I click '.js-backwpup-onboarding-step-3' button to continue
+  Scenario: Setup FTP from Dashboard (After Onboarding)
     When I Configure web server storage
     And I go '/wp-admin/admin.php?page=backwpup'
     Then I should see 'mixed' job cards

--- a/src/backwpup/features/storages/msazure.feature
+++ b/src/backwpup/features/storages/msazure.feature
@@ -1,14 +1,12 @@
-@bwupsetup @bwpupstorage @bwpupsmoke
+@bwupsetup @bwpupstorage @bwpupsmoke @bwpupstoragemsazure
 
-Feature: Should be able to setup other storage
+Feature: Should be able to work with Microsoft Azure storage
 
-  Background:
+  Scenario: Setup Microsoft Azure Storage
     Given I am logged in
     And I delete backwpup plugin
     And plugin is installed 'backwpup-pro'
     And plugin is activated
-
-  Scenario: Setup Microsoft Azure Storage
     And I go '/wp-admin/admin.php?page=backwpup'
     When I click '.js-backwpup-onboarding-step-2' button to continue
     And I click '.js-backwpup-onboarding-step-3' button to continue

--- a/src/backwpup/steps/general.ts
+++ b/src/backwpup/steps/general.ts
@@ -53,8 +53,11 @@ When('I set up {string} storage', async function (this: ICustomWorld, storagePro
         response.url().includes('/backwpup/v1/getblock') &&
         response.status() === 200
     );
-
-    await this.storage.setupMSAzure();
+    if (storageType === 'MSAZURE') {
+        await this.storage.setupMSAzure();
+    } else if (storageType === 'FTP') {
+        await this.storage.setupFTP();
+    }
 });
 
 Then('{string} storage should be selected', async function (this: ICustomWorld, storageProvider: string) {

--- a/src/backwpup/steps/general.ts
+++ b/src/backwpup/steps/general.ts
@@ -2,6 +2,8 @@ import {Then, When} from "@cucumber/cucumber";
 import {ICustomWorld} from "../common/custom-world";
 import {expect, Page} from "@playwright/test";
 import {BackupRowData} from "../utils/types";
+import { waitForBackupJobCompletion } from "../utils/helpers";
+import { configurations } from '../../../utils/configurations';
 
 /**
  * Executes the step to enable all settings.
@@ -26,15 +28,13 @@ Then('the backup should be added to the table', async function (this: ICustomWor
 });
 
 Then('{string} backup is generated and added to history', async function (this: ICustomWorld, backupNumber: string) {
-    const progressBar = this.page.locator('.progress-bar');
-    const progressText = this.page.locator('.progress-step span');
-    await progressBar.waitFor({ state: 'visible', timeout: 10000 });
-
-    //TODO:: check the possibility of using other option that won't rely on timeout.
-    await expect(progressText).toHaveText('100%', { timeout: 600000 });
-    await progressBar.waitFor({ state: 'hidden', timeout: 10000 });
-
-    await this.page.waitForLoadState('networkidle');
+    await waitForBackupJobCompletion(this.page);
+    // Make sure we are on the backup history page (Dashboard) and the new backups are visible (After page loads)
+    await this.page.goto(
+        `${configurations.baseUrl}/wp-admin/admin.php?page=backwpup`, {
+            waitUntil: 'networkidle'
+        }
+    );
     const currentBackups = await captureBackupTableData(this.page)
     expect(currentBackups.length).toBe(this.initialBackups.length + parseInt(backupNumber));
 });

--- a/src/backwpup/steps/general.ts
+++ b/src/backwpup/steps/general.ts
@@ -39,7 +39,15 @@ Then('{string} backup is generated and added to history', async function (this: 
     expect(currentBackups.length).toBe(this.initialBackups.length + parseInt(backupNumber));
 });
 
-
+When(
+    'I set up {string} storage for first backup',
+    async function (this: ICustomWorld, storageProvider: string) {
+        const storageType = storageProvider.toUpperCase();
+        if (storageType === 'FTP') {
+            await this.storage.setupFTPOnboarding();
+        }
+    }
+);
 When('I set up {string} storage', async function (this: ICustomWorld, storageProvider: string) {
     await this.page.locator('.backwpup-job-card button[data-content="storages"]').first().click();
     const storageType = storageProvider.toUpperCase();
@@ -59,7 +67,11 @@ When('I set up {string} storage', async function (this: ICustomWorld, storagePro
         await this.storage.setupFTP();
     }
 });
-
+Then('{string} storage should be selected for first backup', async function (this: ICustomWorld, storageProvider: string) {
+    const storageType = storageProvider.toUpperCase();
+    const isChecked  = await this.page.isChecked(`#destination-${storageType}`);
+    expect(isChecked).toBe(true);
+});
 Then('{string} storage should be selected', async function (this: ICustomWorld, storageProvider: string) {
     const storageType = storageProvider.toUpperCase();
     await this.page.locator('.backwpup-job-card button[data-content="storages"]').first().click();

--- a/src/backwpup/steps/onboarding.ts
+++ b/src/backwpup/steps/onboarding.ts
@@ -1,6 +1,7 @@
 import {Then, When} from "@cucumber/cucumber";
 import {ICustomWorld} from "../../common/custom-world";
 import {expect, Page} from "@playwright/test";
+import { waitForBackupJobCompletion } from "../utils/helpers";
 
 /**
  * Click on save and continue button during onboarding.
@@ -22,26 +23,17 @@ When('I Configure web server storage', async function (this: ICustomWorld) {
 
     //Save and submit onboarding form
     await this.page.click('.js-backwpup-onboarding-submit-form');
+    await waitForBackupJobCompletion(this.page);
 
-    await this.page.waitForTimeout(60000);
-
-    const closeButton = '#showworkingclose'
-    await this.page.waitForSelector(closeButton, {
-        state: 'visible',
-        timeout: 10000
-    });
-    await this.page.click(closeButton)
+    const closeButton = '#showworkingclose';
+    await this.page.click(closeButton);
 });
 
 Then('I save and submit the onboarding form', async function (this: ICustomWorld) {
+    const closeButton = 'button#showworkingclose';
     //Save and submit onboarding form
     await this.page.click('.js-backwpup-onboarding-submit-form');
-
-    const closeButton = '#showworkingclose';
-    await this.page.waitForSelector(closeButton, {
-        state: 'visible',
-        timeout: 100000
-    });
+    await waitForBackupJobCompletion(this.page);
     await this.page.click(closeButton);
 });
 

--- a/src/backwpup/steps/onboarding.ts
+++ b/src/backwpup/steps/onboarding.ts
@@ -33,6 +33,17 @@ When('I Configure web server storage', async function (this: ICustomWorld) {
     await this.page.click(closeButton)
 });
 
+Then('I save and submit the onboarding form', async function (this: ICustomWorld) {
+    //Save and submit onboarding form
+    await this.page.click('.js-backwpup-onboarding-submit-form');
+
+    const closeButton = '#showworkingclose';
+    await this.page.waitForSelector(closeButton, {
+        state: 'visible',
+        timeout: 100000
+    });
+    await this.page.click(closeButton);
+});
 
 /**
  * Set backup frequency to a specific period

--- a/src/backwpup/utils/helpers.ts
+++ b/src/backwpup/utils/helpers.ts
@@ -1,0 +1,42 @@
+import { Page } from "@playwright/test";
+
+/**
+ * Waits for a backup job to complete by monitoring the job status indicators.
+ * 
+ * This function monitors the backup job execution by waiting for specific UI elements
+ * to appear and disappear, indicating the job's progress and completion.
+ * 
+ * @param page - The Playwright Page instance to interact with
+ * @returns A Promise that resolves when the backup job has completed
+ * 
+ * @remarks
+ * The function waits for the following sequence:
+ * 1. Network to be idle
+ * 2. Running job indicator to be visible
+ * 3. Close button to become visible
+ * 4. Abort button to become hidden (indicating job completion)
+ * 5. Network to be idle again (No more requests to check job status)
+ * 
+ * Each selector wait has a timeout of 100 seconds to accommodate long-running backup operations.
+ * 
+ * @throws Will throw if any of the expected elements don't appear/disappear within the timeout period
+ */
+export const waitForBackupJobCompletion = async (page: Page): Promise<void> => {
+    const runningJob = '#runningjob';
+    const closeButton = 'button#showworkingclose';
+    const abortButton = 'button#abortbutton';
+    await page.waitForLoadState('networkidle');
+    await page.waitForSelector(runningJob, {
+        state: 'visible',
+        timeout: 100000
+    });
+    await page.waitForSelector(closeButton, {
+        state: 'visible',
+        timeout: 100000
+    });
+    await page.waitForSelector(abortButton, {
+        state: 'hidden',
+        timeout: 100000
+    });
+    await page.waitForLoadState('networkidle');
+};

--- a/src/backwpup/utils/storage.ts
+++ b/src/backwpup/utils/storage.ts
@@ -77,4 +77,17 @@ export class StorageUtils {
             response.status() === 200
         );
     }
+    public setupFTP = async (): Promise<void> => {
+        await this.page.locator('#ftphost').fill(BACKWPUP_INFOS.ftp.host);
+        await this.page.locator('#ftpuser').fill(BACKWPUP_INFOS.ftp.username);
+        await this.page.locator('#ftppass').fill(BACKWPUP_INFOS.ftp.password);
+        await this.page.locator('#ftphostport').fill(BACKWPUP_INFOS.ftp.port ?? '21');
+
+        await this.page.click('.js-backwpup-test-FTP-storage');
+
+        await this.page.waitForResponse(response =>
+            response.url().includes('/backwpup/v1/cloudsaveandtest') &&
+            response.status() === 200
+        );
+    }
 }

--- a/src/backwpup/utils/storage.ts
+++ b/src/backwpup/utils/storage.ts
@@ -99,10 +99,14 @@ export class StorageUtils {
      * @return {Promise<void>}
      */
     public setupFTP = async (): Promise<void> => {
+        // Text fields
         await this.page.locator('#ftphost').fill(BACKWPUP_INFOS.ftp.host);
         await this.page.locator('#ftpuser').fill(BACKWPUP_INFOS.ftp.username);
         await this.page.locator('#ftppass').fill(BACKWPUP_INFOS.ftp.password);
         await this.page.locator('#ftphostport').fill(BACKWPUP_INFOS.ftp.port ?? '21');
+        // Checkboxes
+        await this.page.locator('#ftpssl').setChecked(BACKWPUP_INFOS.ftp.ssl, { force: true });
+        await this.page.locator('#ftppasv').setChecked(BACKWPUP_INFOS.ftp.passiveMode, { force: true });
         const currentValue = await this.page.locator('#ftpdir').inputValue();
         const timestamp = Date.now();
         // Changing the directory name to prevent old backups to appear and affect the test

--- a/src/backwpup/utils/storage.ts
+++ b/src/backwpup/utils/storage.ts
@@ -59,8 +59,8 @@ export class StorageUtils {
      */
     public setupMSAzure = async (): Promise<void> => {
 
-        await this.page.type('#msazureaccname', BACKWPUP_INFOS.msAccountName);
-        await this.page.type('#msazurekey', BACKWPUP_INFOS.msAccessKey);
+        await this.page.type('#msazureaccname', BACKWPUP_INFOS.msazure.accountName);
+        await this.page.type('#msazurekey', BACKWPUP_INFOS.msazure.accessKey);
 
         await this.page.waitForResponse(response =>
             response.url().includes('admin-ajax.php') &&

--- a/src/backwpup/utils/storage.ts
+++ b/src/backwpup/utils/storage.ts
@@ -77,6 +77,22 @@ export class StorageUtils {
             response.status() === 200
         );
     }
+    public setupFTPOnboarding = async (): Promise<void> => {
+        const ftpButton =
+            '#backwpup-onboarding-panes .js-backwpup-toggle-storage[data-storage="FTP"]';
+        const ftpSidebar = '#backwpup-sidebar #sidebar-storage-FTP';
+        await this.page
+            .click(
+                ftpButton
+            );
+        await this.page.waitForSelector(
+            ftpSidebar,
+            {
+                state: 'visible'
+            }
+        );
+        await this.setupFTP();
+    }
     /**
      * Configures FTP storage settings and tests the connection.
      *
@@ -87,7 +103,10 @@ export class StorageUtils {
         await this.page.locator('#ftpuser').fill(BACKWPUP_INFOS.ftp.username);
         await this.page.locator('#ftppass').fill(BACKWPUP_INFOS.ftp.password);
         await this.page.locator('#ftphostport').fill(BACKWPUP_INFOS.ftp.port ?? '21');
-
+        const currentValue = await this.page.locator('#ftpdir').inputValue();
+        const timestamp = Date.now();
+        // Changing the directory name to prevent old backups to appear and affect the test
+        await this.page.locator('#ftpdir').fill(`${currentValue}${timestamp}`);
         await this.page.click('.js-backwpup-test-FTP-storage');
 
         await this.page.waitForResponse(response =>

--- a/src/backwpup/utils/storage.ts
+++ b/src/backwpup/utils/storage.ts
@@ -77,6 +77,11 @@ export class StorageUtils {
             response.status() === 200
         );
     }
+    /**
+     * Configures FTP storage settings and tests the connection.
+     *
+     * @return {Promise<void>}
+     */
     public setupFTP = async (): Promise<void> => {
         await this.page.locator('#ftphost').fill(BACKWPUP_INFOS.ftp.host);
         await this.page.locator('#ftpuser').fill(BACKWPUP_INFOS.ftp.username);


### PR DESCRIPTION
# Description

Fixes [#1011](https://github.com/wp-media/backwpup-pro/issues/1011)

## Type of change

- [x] New feature (non-breaking change which adds functionality).
- [x] Sub-task of [#959](https://github.com/wp-media/backwpup-pro/issues/959)

## Detailed scenario

Check the issue

### What was tested

Tested FTP storage setup and backup

### How to test

Run the node `./node_modules/@cucumber/cucumber/bin/cucumber-js -p default --tags @bwpupstorageftp` for this specific test

Run `npm run test:bwpupstorage` to test all available storages

### Result of the test (Sep 4, 2025)
<img width="987" height="195" alt="image" src="https://github.com/user-attachments/assets/c6109af6-c610-46a4-9233-3a1a98b6dfc7" />

## Technical description

### Documentation

Add a scenario to set up and create a backup of FTP storage

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification
n/a
