### PR TITLE
Capture new console error after apply LCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ E2E tests here are written with Playwright. Without further ado, let's meet belo
  ## Running Tests
  - Don't forget to install the [helper plugin](https://github.com/wp-media/wp-rocket-e2e-test-helper)
  - To run tests on playwright, simply run `npx playwright test` or `npm run test:e2e` which ever you prefer.
- 
+- To run Visual regression with certain feature run 
+`npm run test:vr --wproption=lazyloadCssBgImg` This means to run visual regression for the pages defined for this feature LLCSSBG after enabling it
  
  ## Debugging Tests
  Use `npx playwright test --debug` to control and get a view of each test step.

--- a/README.md
+++ b/README.md
@@ -27,11 +27,9 @@ E2E tests here are written with Playwright. Without further ado, let's meet belo
  You can find this [here](https://github.com/wp-media/wp-rocket-e2e/blob/trunk/config/wp.config.sample.ts)
  
  ## Running Tests
- - Please delete the debug.log from your test site before running tests, We will automate this step in the future.
  - Don't forget to install the [helper plugin](https://github.com/wp-media/wp-rocket-e2e-test-helper)
  - To run tests on playwright, simply run `npx playwright test` or `npm run test:e2e` which ever you prefer.
  
- **NB:** By default, test will run in headless mode.
  
  ## Debugging Tests
  Use `npx playwright test --debug` to control and get a view of each test step.
@@ -39,7 +37,10 @@ E2E tests here are written with Playwright. Without further ado, let's meet belo
  You can also run `npx playwright test --headed` to view the tests being executed on the browser.
  
  ## Reporting
- At the end of a failed test cycle, playwright will launch a temporary server and open reports with videos and screenshot of failed tests.
+ - In order to have report at the shared folder /var/shared/rocket-e2e-reports on remote e2e server, we can run this "WPRversion_e2e_testType_branch"
+ `npm run test:e2e --tag=wpr3.19.4_e2e_all_dev` This means the test ran using WPR version 3.19.4 and e2e develop branch to run all tests
+
+ - At the end of a failed test cycle, playwright will launch a temporary server and open reports with videos and screenshot of failed tests.
  
 If you ever get failed tests like the one below, it indicates that WP Rocket has some related errors in debug.log
 ![Screenshot 2023-04-27 at 09 55 37](https://user-images.githubusercontent.com/38788055/234812244-c1cd0c87-702a-49a9-baf6-0fab7afd2cd0.png)

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "test:llcssbg": "$npm_package_config_testCommand --tags @llcssbg",
     "test:delayjs": "$npm_package_config_testCommand --tags @delayjs",
     "test:lcp": "$npm_package_config_testCommand --tags @lcp",
+    "test:long-test": "$npm_package_config_testCommand --tags @long-test",
     "test:priorityelements": "$npm_package_config_testCommand --tags @priorityelements",
     "test:preloadfonts": "$npm_package_config_testCommand --tags @preloadfonts",
     "test:test": "$npm_package_config_testCommand --tags @test",

--- a/src/features/lcp-beacon-script.feature
+++ b/src/features/lcp-beacon-script.feature
@@ -12,7 +12,7 @@ Feature: Beacon script captures the right images.
   Scenario Outline: Beacon captures expected images and no console errors in desktop for <url>
     Given I log out
     And I visit the url "<url>" for 'desktop'
-    Then 'lcp and atf' should be as expected for 'desktop' at "<url>"
+    When 'lcp and atf' should be as expected for 'desktop' at "<url>"
     And I am logged in
     And I clear cache
     And I log out

--- a/src/features/lcp-beacon-script.feature
+++ b/src/features/lcp-beacon-script.feature
@@ -33,7 +33,6 @@ Feature: Beacon script captures the right images.
     Examples:
       | url                                |
       | lcp_bg_multimage_template          |
-      | lcp_bg_responsive_webkit_template  |
       | lcp_image_withspecialchar_template |
       | lcp_withfetchpriorityinurl_template|
       | lcp_picture_template2              |

--- a/src/features/lcp-beacon-script.feature
+++ b/src/features/lcp-beacon-script.feature
@@ -28,11 +28,12 @@ Feature: Beacon script captures the right images.
     And I am logged in
     And I clear cache
     And I log out
-    Then validate that url "<url>" in 'desktop' does not have console errors different than nowprocket
-
+    Then no error in the console different than nowprocket page "<url>"
+   
     Examples:
       | url                                |
       | lcp_bg_multimage_template          |
+      | lcp_bg_responsive_webkit_template  |
       | lcp_image_withspecialchar_template |
       | lcp_withfetchpriorityinurl_template|
       | lcp_picture_template2              |
@@ -46,9 +47,6 @@ Feature: Beacon script captures the right images.
       | lcp_multiple_background_pseudo_bg_template |
       | lcp_pseudo_class_element           |
       | lcp_picture_template2_maxheight    |
-      | lcp_picture_issue                  |
-      | lcp_specialchar_template           |
-      | lcp_specialchar2                   |
     
   
 

--- a/src/features/lcp-beacon-script.feature
+++ b/src/features/lcp-beacon-script.feature
@@ -21,7 +21,7 @@ Feature: Beacon script captures the right images.
     And plugin 'force-wp-mobile' is deactivated
     Then 'lcp and atf' should be as expected for 'mobile'
 
-  @test
+  @long-test
   Scenario Outline: Beacon applied and no console errors in desktop for <url>
     Given I log out
     And I visit the url "<url>" for 'desktop'
@@ -33,10 +33,8 @@ Feature: Beacon script captures the right images.
     Examples:
       | url                                |
       | lcp_bg_multimage_template          |
-      | lcp_bg_responsive_webkit_template  |
       | lcp_image_withspecialchar_template |
       | lcp_withfetchpriorityinurl_template|
-      | lcp_picture_template               |
       | lcp_picture_template2              |
       | lcp_section_template_relative      |
       | lcp_section_template2              |
@@ -45,7 +43,6 @@ Feature: Beacon script captures the right images.
       | lcp_picture_media_type_mixed       |
       | lcp_picture_relative               |
       | lcp_responsive_image               |
-      | lcp_bg_responsive_imgset_template  |
       | lcp_multiple_background_pseudo_bg_template |
       | lcp_pseudo_class_element           |
       | lcp_picture_template2_maxheight    |

--- a/src/features/lcp-beacon-script.feature
+++ b/src/features/lcp-beacon-script.feature
@@ -7,11 +7,15 @@ Feature: Beacon script captures the right images.
         And plugin is activated
         And I go to 'wp-admin/options-general.php?page=wprocket#dashboard'
         And plugin 'sitepress-multilingual-cms' is deactivated
-
+@test
     Scenario: Beacon captures expected images in desktop
-        When I log out
+        Given I log out
         And I visit the urls for 'desktop'
-        Then 'lcp and atf' should be as expected for 'desktop'
+        When 'lcp and atf' should be as expected for 'desktop'
+        And I am logged in
+        And I clear cache
+        And I log out
+        Then validate that all urls in 'desktop' not having console errors different than nowprocket
 
     Scenario: Beacon captures expected images in mobile
         Given I install plugin 'https://github.com/wp-media/wp-rocket-e2e-test-helper/raw/main/helper-plugin/force-wp-mobile.zip'

--- a/src/features/lcp-beacon-script.feature
+++ b/src/features/lcp-beacon-script.feature
@@ -7,20 +7,71 @@ Feature: Beacon script captures the right images.
         And plugin is activated
         And I go to 'wp-admin/options-general.php?page=wprocket#dashboard'
         And plugin 'sitepress-multilingual-cms' is deactivated
-@test
-    Scenario: Beacon captures expected images in desktop
-        Given I log out
-        And I visit the urls for 'desktop'
-        When 'lcp and atf' should be as expected for 'desktop'
-        And I am logged in
-        And I clear cache
-        And I log out
-        Then validate that all urls in 'desktop' not having console errors different than nowprocket
 
-    Scenario: Beacon captures expected images in mobile
-        Given I install plugin 'https://github.com/wp-media/wp-rocket-e2e-test-helper/raw/main/helper-plugin/force-wp-mobile.zip'
-        And plugin 'force-wp-mobile' is activated
-        When I log out
-        And I visit the urls for 'mobile'
-        And plugin 'force-wp-mobile' is deactivated
-        Then 'lcp and atf' should be as expected for 'mobile'
+  @test
+  Scenario Outline: Beacon captures expected images and no console errors in desktop for <url>
+    Given I log out
+    And I visit the url "<url>" for 'desktop'
+    Then 'lcp and atf' should be as expected for 'desktop' at "<url>"
+    And I am logged in
+    And I clear cache
+    And I log out
+    Then validate that url "<url>" in 'desktop' does not have console errors different than nowprocket
+
+    Examples:
+      | url                                |
+      | lcp_bg_inline_template             |
+      | lcp_bg_samestyle_template          |
+      | lcp_img_loadedbydynamicjs_template |
+      | lcp_img_loadedbyjs_template        |
+      | lcp_bg_multimage_template          |
+      | lcp_with_space_after_title         |
+      | lcp_test_template                  |
+      | lcp_bg_responsive_webkit_template  |
+      | lcp_regular_image_template         |
+      | lcp_dynamicvisibility              |
+      | lcp_attribute_template             |
+      | lcp_no_dimension_svg               |
+      | lcp_no_dimensions_picture          |
+      | lcp_no_dimension_absolute_url      |
+      | lcp_image_withspecialchar_template |
+      | lcp_img_addedbydynamicstyle_template |
+      | lcp_withfetchpriorityhigh_template |
+      | lcp_single_double                  |
+      | lcp_withfetchprioritylow_template  |
+      | lcp_withfetchpriorityempty_template|
+      | lcp_withfetchpriorityinurl_template|
+      | lcp_video_poster_template          |
+      | lcp_big_image_template             |
+      | lcp_no_fetchpriority               |
+      | lcp_no_images                      |
+      | lcp_picture_template               |
+      | lcp_picture_template2              |
+      | lcp_bg_img_in_section              |
+      | lcp_section_template_relative      |
+      | lcp_section_template2              |
+      | lcp_bg_relative_attribute_incss    |
+      | lcp_bg_img_in_header_template      |
+      | lcp_6647_svgbg_template            |
+      | lcp_6599_template2                 |
+      | lcp_picture_media_type_mixed       |
+      | lcp_picture_relative               |
+      | lcp_invisibleatf                   |
+      | lcp_invisibleatf2                  |
+      | lcp_invisibleatf3                  |
+      | lcp_hidden_visibility              |
+      | lcp_responsive_image               |
+      | lcp_bg_responsive_imgset_template  |
+      | lcp_multiple_background_pseudo_bg_template |
+      | lcp_pseudo_class_element           |
+      | lcp_picture_template2_maxheight    |
+      | lcp_picture_issue                  |
+      | lcp_specialchar_template           |
+      | lcp_specialchar2                   |
+      | lcp_images_in_root                 |
+      | lcp_before_after                   |
+      | lcp_resposive_imagegrid            |
+      | lcp_images_intersecting_b          |
+      | lcp_images_intersecting_a          |
+      | lcp_transformed_images_template    |
+      | lcp_nested_images_template         |

--- a/src/features/lcp-beacon-script.feature
+++ b/src/features/lcp-beacon-script.feature
@@ -8,11 +8,23 @@ Feature: Beacon script captures the right images.
         And I go to 'wp-admin/options-general.php?page=wprocket#dashboard'
         And plugin 'sitepress-multilingual-cms' is deactivated
 
+  Scenario: Beacon captures expected images in desktop
+    When I log out
+    And I visit the urls for 'desktop'
+    Then 'lcp and atf' should be as expected for 'desktop'
+
+  Scenario: Beacon captures expected images in mobile
+    Given I install plugin 'https://github.com/wp-media/wp-rocket-e2e-test-helper/raw/main/helper-plugin/force-wp-mobile.zip'
+    And plugin 'force-wp-mobile' is activated
+    When I log out
+    And I visit the urls for 'mobile'
+    And plugin 'force-wp-mobile' is deactivated
+    Then 'lcp and atf' should be as expected for 'mobile'
+
   @test
-  Scenario Outline: Beacon captures expected images and no console errors in desktop for <url>
+  Scenario Outline: Beacon applied and no console errors in desktop for <url>
     Given I log out
     And I visit the url "<url>" for 'desktop'
-    When 'lcp and atf' should be as expected for 'desktop' at "<url>"
     And I am logged in
     And I clear cache
     And I log out
@@ -20,46 +32,18 @@ Feature: Beacon script captures the right images.
 
     Examples:
       | url                                |
-      | lcp_bg_inline_template             |
-      | lcp_bg_samestyle_template          |
-      | lcp_img_loadedbydynamicjs_template |
-      | lcp_img_loadedbyjs_template        |
       | lcp_bg_multimage_template          |
-      | lcp_with_space_after_title         |
-      | lcp_test_template                  |
       | lcp_bg_responsive_webkit_template  |
-      | lcp_regular_image_template         |
-      | lcp_dynamicvisibility              |
-      | lcp_attribute_template             |
-      | lcp_no_dimension_svg               |
-      | lcp_no_dimensions_picture          |
-      | lcp_no_dimension_absolute_url      |
       | lcp_image_withspecialchar_template |
-      | lcp_img_addedbydynamicstyle_template |
-      | lcp_withfetchpriorityhigh_template |
-      | lcp_single_double                  |
-      | lcp_withfetchprioritylow_template  |
-      | lcp_withfetchpriorityempty_template|
       | lcp_withfetchpriorityinurl_template|
-      | lcp_video_poster_template          |
-      | lcp_big_image_template             |
-      | lcp_no_fetchpriority               |
-      | lcp_no_images                      |
       | lcp_picture_template               |
       | lcp_picture_template2              |
-      | lcp_bg_img_in_section              |
       | lcp_section_template_relative      |
       | lcp_section_template2              |
       | lcp_bg_relative_attribute_incss    |
-      | lcp_bg_img_in_header_template      |
-      | lcp_6647_svgbg_template            |
       | lcp_6599_template2                 |
       | lcp_picture_media_type_mixed       |
       | lcp_picture_relative               |
-      | lcp_invisibleatf                   |
-      | lcp_invisibleatf2                  |
-      | lcp_invisibleatf3                  |
-      | lcp_hidden_visibility              |
       | lcp_responsive_image               |
       | lcp_bg_responsive_imgset_template  |
       | lcp_multiple_background_pseudo_bg_template |
@@ -68,10 +52,7 @@ Feature: Beacon script captures the right images.
       | lcp_picture_issue                  |
       | lcp_specialchar_template           |
       | lcp_specialchar2                   |
-      | lcp_images_in_root                 |
-      | lcp_before_after                   |
-      | lcp_resposive_imagegrid            |
-      | lcp_images_intersecting_b          |
-      | lcp_images_intersecting_a          |
-      | lcp_transformed_images_template    |
-      | lcp_nested_images_template         |
+    
+  
+
+ 

--- a/src/support/results/expectedResultsDesktop.json
+++ b/src/support/results/expectedResultsDesktop.json
@@ -423,14 +423,12 @@
   "lcp_picture_responsive_type": {
     "comment": "Has a bug currently in UI#7547",
     "lcp": [
-      "https://imagify.rocketlabsqa.ovh/wp-content/uploads/2024/05/home-new-bg-free-img-u2014-kopia-600x338.jpg.avif 1024w, https://imagify.rocketlabsqa.ovh/wp-content/uploads/2024/05/home-new-bg-free-img-u2014-kopia-100x100.jpg.avif 768w, https://imagify.rocketlabsqa.ovh/wp-content/uploads/2024/05/home-new-bg-free-img-u2014-kopia-1536x864.jpg.avif 1536w, https://imagify.rocketlabsqa.ovh/wp-content/uploads/2024/05/home-new-bg-free-img-u2014-kopia-450x450.jpg.avif 1200w" ,
-      "https://imagify.rocketlabsqa.ovh/wp-content/uploads/2024/05/home-new-bg-free-img-u2014-kopia-600x338.jpg.webp 1024w, https://imagify.rocketlabsqa.ovh/wp-content/uploads/2024/05/home-new-bg-free-img-u2014-kopia-450x450.jpg.webp 300w, https://imagify.rocketlabsqa.ovh/wp-content/uploads/2024/05/home-new-bg-free-img-u2014-kopia-100x100.jpg.webp 768w",
-      "https://imagify.rocketlabsqa.ovh/wp-content/uploads/2024/05/home-new-bg-free-img-%E2%80%94-kopia-1024x576.jpg", "https://imagify.rocketlabsqa.ovh/wp-content/uploads/2024/05/home-new-bg-free-img-%E2%80%94-kopia-450x450.jpg 1024w"
+      "https://imagify.rocketlabsqa.ovh/wp-content/uploads/2024/05/home-new-bg-free-img-u2014-kopia-600x338.jpg.avif 1024w, https://imagify.rocketlabsqa.ovh/wp-content/uploads/2024/05/home-new-bg-free-img-u2014-kopia-100x100.jpg.avif 768w, https://imagify.rocketlabsqa.ovh/wp-content/uploads/2024/05/home-new-bg-free-img-u2014-kopia-1536x864.jpg.avif 1536w, https://imagify.rocketlabsqa.ovh/wp-content/uploads/2024/05/home-new-bg-free-img-u2014-kopia-450x450.jpg.avif 1200w"
     ],
     "viewport": [
       "/wp-content/rocket-test-data/images/lcp/istockphoto-1148323720-612x612-1-300x186.jpg.avif 1024w, /wp-content/rocket-test-data/images/lcp/istockphoto-1148323720-612x612-1-150x150.jpg.avif 768w",
       "/wp-content/rocket-test-data/images/lcp/istockphoto-1148323720-612x612-1.jpg.webp 1024w, /wp-content/rocket-test-data/images/lcp/istockphoto-1148323720-612x612-1-450x380.jpg.webp 450w, /wp-content/rocket-test-data/images/lcp/istockphoto-1148323720-612x612-1-600x373.jpg.webp 600w",
-      "https://new.rocketlabsqa.ovh/wp-content/rocket-test-data/images/lcp/istockphoto-1148323720-612x612-1.jpg", "/wp-content/rocket-test-data/images/lcp/istockphoto-1148323720-612x612-1-600x373.jpg 1024w, /wp-content/rocket-test-data/images/lcp/istockphoto-1148323720-612x612-1-450x380.jpg 1920w"
+      "https://new.rocketlabsqa.ovh/wp-content/rocket-test-data/images/lcp/istockphoto-1148323720-612x612-1.jpg"
   ],
     "enabled": true
   },

--- a/src/support/results/expectedResultsDesktop.json
+++ b/src/support/results/expectedResultsDesktop.json
@@ -66,6 +66,7 @@
     "enabled": true
   },
   "lcp_bg_responsive_webkit_template": {
+    "comment":"Has GH 7563",
     "lcp": [
       "https://fastly.picsum.photos/id/976/200/300.jpg?hmac=s1Uz9fgJv32r8elfaIYn7pLpQXps7X9oYNwC5XirhO8",
       "/wp-content/rocket-test-data/images/fixtheissue.jpg"
@@ -221,6 +222,7 @@
     "enabled": true
   },
   "lcp_picture_template": {
+    "comment":"related issue #7584 which will affect console error scenario",
     "lcp": [
       "/wp-content/rocket-test-data/images/test3.gif",
       "/rocket-test-data/images/lcp/testjpg2.jpg",
@@ -393,7 +395,7 @@
       "/wp-content/rocket-test-data/images/lcp/testavif.avif", "/wp-content/rocket-test-data/images/lcp/testwebp.webp",
       "https://fastly.picsum.photos/id/976/200/300.jpg?hmac=s1Uz9fgJv32r8elfaIYn7pLpQXps7X9oYNwC5XirhO8", "https://rocketlabsqa.ovh/wp-content/rocket-test-data/images/fixtheissue.jpg"
      ],
-    "enabled": false
+    "enabled": true
   },
   "lcp_multiple_background_pseudo_bg_template": {
     "lcp": [
@@ -430,7 +432,7 @@
       "/wp-content/rocket-test-data/images/lcp/istockphoto-1148323720-612x612-1.jpg.webp 1024w, /wp-content/rocket-test-data/images/lcp/istockphoto-1148323720-612x612-1-450x380.jpg.webp 450w, /wp-content/rocket-test-data/images/lcp/istockphoto-1148323720-612x612-1-600x373.jpg.webp 600w",
       "https://new.rocketlabsqa.ovh/wp-content/rocket-test-data/images/lcp/istockphoto-1148323720-612x612-1.jpg", "/wp-content/rocket-test-data/images/lcp/istockphoto-1148323720-612x612-1-600x373.jpg 1024w, /wp-content/rocket-test-data/images/lcp/istockphoto-1148323720-612x612-1-450x380.jpg 1920w"
   ],
-    "enabled": false
+    "enabled": true
   },
   "lcp_picture_template2_maxheight": {
     "lcp": [

--- a/src/support/results/expectedResultsDesktop.json
+++ b/src/support/results/expectedResultsDesktop.json
@@ -416,7 +416,7 @@
     "viewport": [
     "/wp-content/rocket-test-data/images/lcp/WF4.jpg.avif", "/wp-content/rocket-test-data/images/lcp/WF4.jpg.webp", 
     "/wp-content/rocket-test-data/images/lcp/WF4.jpg"],
-    "enabled": false
+    "enabled": true
   },
   "lcp_picture_responsive_type": {
     "comment": "Has a bug currently in UI#7547",

--- a/src/support/results/expectedResultsDesktop.json
+++ b/src/support/results/expectedResultsDesktop.json
@@ -89,31 +89,6 @@
     ],
     "enabled": true
   },
-  "lcp_bg_reponsive_imgset_template": {
-    "lcp": [
-      "/wp-content/rocket-test-data/images/lcp/testavif.avif",
-      "/wp-content/rocket-test-data/images/lcp/testwebp.webp"
-    ],
-    "viewport": [
-      "https://fastly.picsum.photos/id/976/200/300.jpg?hmac=s1Uz9fgJv32r8elfaIYn7pLpQXps7X9oYNwC5XirhO8",
-      "https://rocketlabsqa.ovh/wp-content/rocket-test-data/images/fixtheissue.jpg"
-    ],
-    "enabled": true
-  },
-  "lcp_rsponsive_imagegrid": {
-    "lcp": [
-      "/wp-content/rocket-test-data/images/lcp/underwater.jpg"
-    ],
-    "viewport": [
-      "/wp-content/rocket-test-data/images/lcp/wedding.jpg",
-      "/wp-content/rocket-test-data/images/lcp/rocks.jpg",
-      "/wp-content/rocket-test-data/images/lcp/testPng.png",
-      "/wp-content/rocket-test-data/images/lcp/testavif.avif",
-      "/wp-content/rocket-test-data/images/file_example_JPG_100kB.jpg",
-      "/wp-content/rocket-test-data/images/maxime-lebrun-6g3Akg708E0-unsplash.jpg"
-    ],
-    "enabled": true
-  },
   "lcp_dynamicvisibility": {
     "lcp": [
       "/wp-content/rocket-test-data/images/flowers.jpg"
@@ -410,9 +385,9 @@
     "enabled": true
   },
   "lcp_bg_responsive_imgset_template": {
-    "comment":"lcp is included in atf",
+    "comment":"lcp is included in atf and 7559",
     "lcp": [
-      "/wp-content/rocket-test-data/images/lcp/testavif.avif", "/wp-content/rocket-test-data/images/lcp/testwebp.webp"
+      "/wp-content/rocket-test-data/images/lcp/testavif.avif"
     ],
     "viewport": [
       "/wp-content/rocket-test-data/images/lcp/testavif.avif", "/wp-content/rocket-test-data/images/lcp/testwebp.webp",
@@ -433,14 +408,15 @@
     "viewport": [],
     "enabled": true
   },
-  "lcp_picture_type": {
-    "comment": "Has a bug currently in UI #7547",
+ "lcp_picture_type": {
+    "comment": "Has a bug currently in UI#7547",
     "lcp": [
-      "/wp-content/rocket-test-data/images/lcp/marchlarge1-scaled.jpg.avif", "/wp-content/rocket-test-data/images/lcp/marchlarge1-scaled.jpg.webp", 
-    "/wp-content/rocket-test-data/images/lcp/marchlarge1-scaled.jpg"],
-    "viewport": ["https://imagify.rocketlabsqa.ovh/wp-content/uploads/2024/05/home-new-bg-free-img-u2014-kopia-600x338.jpg.avif", "https://imagify.rocketlabsqa.ovh/wp-content/uploads/2024/05/home-new-bg-free-img-u2014-kopia-600x338.jpg.webp", 
-    "https://imagify.rocketlabsqa.ovh/wp-content/uploads/2024/05/home-new-bg-free-img-%E2%80%94-kopia-1024x576.jpg"],
-    "enabled": true
+      "https://imagify.rocketlabsqa.ovh/wp-content/uploads/2024/05/home-new-bg-free-img-u2014-kopia-600x338.jpg.avif"],
+
+    "viewport": [
+    "/wp-content/rocket-test-data/images/lcp/WF4.jpg.avif", "/wp-content/rocket-test-data/images/lcp/WF4.jpg.webp", 
+    "/wp-content/rocket-test-data/images/lcp/WF4.jpg"],
+    "enabled": false
   },
   "lcp_picture_responsive_type": {
     "comment": "Has a bug currently in UI#7547",

--- a/src/support/results/expectedResultsDesktop.json
+++ b/src/support/results/expectedResultsDesktop.json
@@ -226,7 +226,7 @@
     "lcp": [
       "/wp-content/rocket-test-data/images/test3.gif",
       "/rocket-test-data/images/lcp/testjpg2.jpg",
-      "/rocket-test-data/images/testjpg3.jpg"
+      "/rocket-test-data/images/lcp/testjpg3.jpg"
     ],
     "viewport": [
       "/rocket-test-data/images/lcp/testwebp.webp",

--- a/src/support/results/expectedResultsDesktop.json
+++ b/src/support/results/expectedResultsDesktop.json
@@ -245,7 +245,7 @@
     ],
     "viewport": [
       "/rocket-test-data/images/test3.gif",
-      "/rocket-test-data/images/testjpg3.jpg",
+      "/rocket-test-data/images/lcp/testjpg3.jpg",
       "/rocket-test-data/images/lcp/testjpg2.jpg"
     ],
     "enabled": true

--- a/src/support/results/expectedResultsDesktop.json
+++ b/src/support/results/expectedResultsDesktop.json
@@ -385,15 +385,15 @@
     "enabled": true
   },
   "lcp_bg_responsive_imgset_template": {
-    "comment":"lcp is included in atf and 7559",
+    "comment":"lcp is included in atf and 7559 and preloaded lcp is wrong 7563 causing 404",
     "lcp": [
-      "/wp-content/rocket-test-data/images/lcp/testavif.avif"
+      "/wp-content/rocket-test-data/images/lcp/testavif.avif","/wp-content/rocket-test-data/images/lcp/testwebp.webp"
     ],
     "viewport": [
       "/wp-content/rocket-test-data/images/lcp/testavif.avif", "/wp-content/rocket-test-data/images/lcp/testwebp.webp",
       "https://fastly.picsum.photos/id/976/200/300.jpg?hmac=s1Uz9fgJv32r8elfaIYn7pLpQXps7X9oYNwC5XirhO8", "https://rocketlabsqa.ovh/wp-content/rocket-test-data/images/fixtheissue.jpg"
      ],
-    "enabled": true
+    "enabled": false
   },
   "lcp_multiple_background_pseudo_bg_template": {
     "lcp": [

--- a/src/support/results/expectedResultsMobile.json
+++ b/src/support/results/expectedResultsMobile.json
@@ -387,7 +387,7 @@
       "/wp-content/rocket-test-data/images/lcp/testavif.avif", "/wp-content/rocket-test-data/images/lcp/testwebp.webp",
       "https://fastly.picsum.photos/id/976/200/300.jpg?hmac=s1Uz9fgJv32r8elfaIYn7pLpQXps7X9oYNwC5XirhO8", "https://rocketlabsqa.ovh/wp-content/rocket-test-data/images/fixtheissue.jpg"
      ],
-    "enabled": false
+    "enabled": true
   },
   "lcp_multiple_background_pseudo_bg_template": {
     "lcp": [

--- a/src/support/results/expectedResultsMobile.json
+++ b/src/support/results/expectedResultsMobile.json
@@ -213,7 +213,7 @@
   "lcp_picture_template2": {
     "lcp": [
       "/rocket-test-data/images/test3.gif",
-      "/rocket-test-data/images/testjpg3.jpg",
+      "/rocket-test-data/images/lcp/testjpg3.jpg",
       "/rocket-test-data/images/lcp/testjpg2.jpg"
     ],
     "viewport": [

--- a/src/support/results/expectedResultsMobile.json
+++ b/src/support/results/expectedResultsMobile.json
@@ -391,10 +391,10 @@
   },
   "lcp_responsive_image": {
     "lcp": [
-      "/wp-content/rocket-test-data/images/lcp/testavif.avif", "/wp-content/rocket-test-data/images/lcp/testwebp.webp 400w, /wp-content/rocket-test-data/images/lcp/testjpg.jpg 800w, /wp-content/rocket-test-data/images/lcp/testPng.png 1600w"
+          "/wp-content/rocket-test-data/images/lcp/testjpg.jpg","/wp-content/rocket-test-data/images/lcp/testjpg2.jpg 500w, /wp-content/rocket-test-data/images/lcp/testjpg3.jpg 1000w, /wp-content/rocket-test-data/images/lcp/testjpg4.jpg 1500w"
     ],
     "viewport": [
-     "/wp-content/rocket-test-data/images/lcp/testjpg.jpg","/wp-content/rocket-test-data/images/lcp/testjpg2.jpg 500w, /wp-content/rocket-test-data/images/lcp/testjpg3.jpg 1000w, /wp-content/rocket-test-data/images/lcp/testjpg4.jpg 1500w"
+       "/wp-content/rocket-test-data/images/lcp/testavif.avif", "/wp-content/rocket-test-data/images/lcp/testwebp.webp 400w, /wp-content/rocket-test-data/images/lcp/testjpg.jpg 800w, /wp-content/rocket-test-data/images/lcp/testPng.png 1600w"
     ],
     "enabled": true
   },
@@ -422,14 +422,15 @@
     "viewport": [],
     "enabled": true
   },
-    "lcp_picture_type": {
+"lcp_picture_type": {
     "comment": "Has a bug currently in UI#7547",
     "lcp": [
-      "/wp-content/rocket-test-data/images/lcp/marchlarge1-scaled.jpg.avif", "/wp-content/rocket-test-data/images/lcp/marchlarge1-scaled.jpg.webp", 
-    "/wp-content/rocket-test-data/images/lcp/marchlarge1-scaled.jpg"],
-    "viewport": ["https://imagify.rocketlabsqa.ovh/wp-content/uploads/2024/05/home-new-bg-free-img-—-kopia-600x338.jpg.avif", "https://imagify.rocketlabsqa.ovh/wp-content/uploads/2024/05/home-new-bg-free-img-—-kopia-600x338.jpg.webp", 
-    "https://imagify.rocketlabsqa.ovh/wp-content/uploads/2024/05/home-new-bg-free-img-—-kopia-1024x576.jpg", "/wp-content/rocket-test-data/images/lcp/EpicFriday2-1-700x394.png.avif",
-    "https://new.rocketlabsqa.ovh/wp-content/rocket-test-data/images/lcp/EpicFriday2-1-700x394.png.webp", "https://new.rocketlabsqa.ovh/wp-content/rocket-test-data/images/lcp/EpicFriday2-1-700x394.png"],
+      "https://imagify.rocketlabsqa.ovh/wp-content/uploads/2024/05/home-new-bg-free-img-u2014-kopia-600x338.jpg.avif"],
+
+    "viewport": [
+    "https://new.rocketlabsqa.ovh/wp-content/rocket-test-data/images/lcp/EpicFriday2-1-700x394.png.webp", "https://new.rocketlabsqa.ovh/wp-content/rocket-test-data/images/lcp/EpicFriday2-1-700x394.png",
+    "/wp-content/rocket-test-data/images/lcp/WF4.jpg.avif", "/wp-content/rocket-test-data/images/lcp/WF4.jpg.webp", 
+    "/wp-content/rocket-test-data/images/lcp/WF4.jpg"],
     "enabled": false
   },
   "lcp_picture_responsive_type": {

--- a/src/support/results/expectedResultsMobile.json
+++ b/src/support/results/expectedResultsMobile.json
@@ -379,7 +379,7 @@
     "enabled": true
   },
   "lcp_bg_responsive_imgset_template": {
-    "comment":"lcp is included in atf and 7559",
+    "comment":"lcp is included in atf and 7559 , 7563",
     "lcp": [
       "/wp-content/rocket-test-data/images/lcp/testavif.avif", "/wp-content/rocket-test-data/images/lcp/testwebp.webp"
     ],
@@ -387,7 +387,7 @@
       "/wp-content/rocket-test-data/images/lcp/testavif.avif", "/wp-content/rocket-test-data/images/lcp/testwebp.webp",
       "https://fastly.picsum.photos/id/976/200/300.jpg?hmac=s1Uz9fgJv32r8elfaIYn7pLpQXps7X9oYNwC5XirhO8", "https://rocketlabsqa.ovh/wp-content/rocket-test-data/images/fixtheissue.jpg"
      ],
-    "enabled": true
+    "enabled": false
   },
   "lcp_multiple_background_pseudo_bg_template": {
     "lcp": [

--- a/src/support/results/expectedResultsMobile.json
+++ b/src/support/results/expectedResultsMobile.json
@@ -402,15 +402,13 @@
     "viewport": [],
     "enabled": true
   },
-"lcp_picture_type": {
+  "lcp_picture_type": {
     "comment": "Has a bug currently in UI#7547",
     "lcp": [
-      "https://imagify.rocketlabsqa.ovh/wp-content/uploads/2024/05/home-new-bg-free-img-u2014-kopia-600x338.jpg.avif"],
-
-    "viewport": [
-    "https://new.rocketlabsqa.ovh/wp-content/rocket-test-data/images/lcp/EpicFriday2-1-700x394.png.webp", "https://new.rocketlabsqa.ovh/wp-content/rocket-test-data/images/lcp/EpicFriday2-1-700x394.png",
-    "/wp-content/rocket-test-data/images/lcp/WF4.jpg.avif", "/wp-content/rocket-test-data/images/lcp/WF4.jpg.webp", 
-    "/wp-content/rocket-test-data/images/lcp/WF4.jpg"],
+       "https://imagify.rocketlabsqa.ovh/wp-content/uploads/2024/05/home-new-bg-free-img-u2014-kopia-600x338.jpg.avif"],
+    "viewport": [  "/wp-content/rocket-test-data/images/lcp/WF4.jpg.avif", "/wp-content/rocket-test-data/images/lcp/WF4.jpg.webp", 
+      "/wp-content/rocket-test-data/images/lcp/WF4.jpg", "/wp-content/rocket-test-data/images/lcp/EpicFriday2-1-700x394.png.avif",
+      "https://new.rocketlabsqa.ovh/wp-content/rocket-test-data/images/lcp/EpicFriday2-1-700x394.png.webp", "https://new.rocketlabsqa.ovh/wp-content/rocket-test-data/images/lcp/EpicFriday2-1-700x394.png"],
     "enabled": false
   },
   "lcp_picture_responsive_type": {

--- a/src/support/results/expectedResultsMobile.json
+++ b/src/support/results/expectedResultsMobile.json
@@ -256,7 +256,7 @@
     "lcp": [
       "/wp-content/rocket-test-data/images/test3.gif",
       "/rocket-test-data/images/lcp/testjpg2.jpg",
-      "/rocket-test-data/images/testjpg3.jpg"
+      "/rocket-test-data/images/lcp/testjpg3.jpg"
     ],
     "viewport": [
       "/rocket-test-data/images/lcp/testwebp.webp",

--- a/src/support/steps/general.ts
+++ b/src/support/steps/general.ts
@@ -451,8 +451,7 @@ Then('no error in the console different than nowprocket page {string}', async fu
 When('validate that all urls in {string} not having console errors different than nowprocket', async function (this: ICustomWorld, formFactor: string) {
     let viewPortWidth: number = 1600,
         viewPortHeight: number = 700,
-        resultFile: string = './src/support/results/expectedResultsDesktop.json',
-        isMobile = 0;
+        resultFile: string = './src/support/results/expectedResultsDesktop.json'
 
     // Set page to be visited in mobile or for preload fonts
     if (formFactor === 'mobile') {

--- a/src/support/steps/general.ts
+++ b/src/support/steps/general.ts
@@ -479,8 +479,8 @@ When(
         const url = `${WP_BASE_URL}/${templateKey}`;
         const urlNowprocket = `${url}?nowprocket`;
 
-        const consoleMsgNowprocket = await getConsoleMsg(this.page, urlNowprocket);
-        const consoleMsgActual = await getConsoleMsg(this.page, url);
+        const consoleMsgNowprocket = await getConsoleMsgNoScroll(this.page, urlNowprocket);
+        const consoleMsgActual = await getConsoleMsgNoScroll(this.page, url);
 
         if (consoleMsgActual.length !== 0) {
             try {
@@ -494,6 +494,33 @@ When(
         }
     }
 );
+
+const getConsoleMsgNoScroll = async (page: Page, url: string): Promise<Array<string>> => {
+    const consoleMsg: string[] = [];
+
+    const consoleHandler = (msg): void => {
+        consoleMsg.push(msg.text());
+    };
+
+    const pageErrorHandler = (error: Error): void => {
+        consoleMsg.push(error.message);
+    };
+
+    // Listen for console messages.
+    page.on('console', consoleHandler);
+
+    // Listen for page errors.
+    page.on('pageerror', pageErrorHandler);
+
+    await page.goto(url);
+    await page.waitForLoadState('load', { timeout: 30000 });
+
+    // Remove the event listeners to prevent duplicate messages.
+    page.off('console', consoleHandler);
+    page.off('pageerror', pageErrorHandler);
+
+    return consoleMsg;
+}
 
 
 const getConsoleMsg = async (page: Page, url: string): Promise<Array<string>> => {

--- a/src/support/steps/general.ts
+++ b/src/support/steps/general.ts
@@ -448,56 +448,52 @@ Then('no error in the console different than nowprocket page {string}', async fu
 /**
  * Executes the step to check for that there is no console error different from the nowprocket pages version.
  */
-When('validate that all urls in {string} not having console errors different than nowprocket', async function (this: ICustomWorld, formFactor: string) {
-    let viewPortWidth: number = 1600,
-        viewPortHeight: number = 700,
-        resultFile: string = './src/support/results/expectedResultsDesktop.json'
+When(
+    "validate that url {string} in {string} does not have console errors different than nowprocket",
+    async function (this: ICustomWorld, templateKey: string, formFactor: string) {
+        let viewPortWidth: number = 1600,
+            viewPortHeight: number = 700,
+            resultFile: string = './src/support/results/expectedResultsDesktop.json';
 
-    // Set page to be visited in mobile or for preload fonts
-    if (formFactor === 'mobile') {
-        viewPortWidth = 389;
-        viewPortHeight = 829;
-        resultFile = './src/support/results/expectedResultsMobile.json';
-    } else if (formFactor === 'preloadfonts') {
-        resultFile = './src/support/results/expectedResultsPreloadFonts.json';
-    }
+        if (formFactor === 'mobile') {
+            viewPortWidth = 389;
+            viewPortHeight = 829;
+            resultFile = './src/support/results/expectedResultsMobile.json';
+        } else if (formFactor === 'preloadfonts') {
+            resultFile = './src/support/results/expectedResultsPreloadFonts.json';
+        }
 
-    const data = await fs.readFile(resultFile, 'utf8');
-    const jsonData = JSON.parse(data);
+        const data = await fs.readFile(resultFile, 'utf8');
+        const jsonData = JSON.parse(data);
 
-    await this.page.setViewportSize({
-        width: viewPortWidth,
-        height: viewPortHeight
-    });
+        await this.page.setViewportSize({
+            width: viewPortWidth,
+            height: viewPortHeight
+        });
 
-    const errors: string[] = [];
+        // Handle missing/disabled templateKey gracefully
+        if (!jsonData[templateKey] || !jsonData[templateKey].enabled) {
+            throw new Error(`Template key "${templateKey}" not found or not enabled in ${resultFile}`);
+        }
 
-    for (const key in jsonData) {
-        if (jsonData[key].enabled === true) {
-            const url = `${WP_BASE_URL}/${key}`;
-            const urlNowprocket = `${url}?nowprocket`;
+        const url = `${WP_BASE_URL}/${templateKey}`;
+        const urlNowprocket = `${url}?nowprocket`;
 
-            const consoleMsgNowprocket = await getConsoleMsg(this.page, urlNowprocket);
-            const consoleMsgActual = await getConsoleMsg(this.page, url);
+        const consoleMsgNowprocket = await getConsoleMsg(this.page, urlNowprocket);
+        const consoleMsgActual = await getConsoleMsg(this.page, url);
 
-            if (consoleMsgActual.length !== 0) {
-                try {
-                    expect(consoleMsgActual).toEqual(consoleMsgNowprocket);
-                } catch (e) {
-                    // Highlight the URL in the error using ANSI escape codes for color
-                    errors.push(
-                        `\x1b[41m\x1b[37mConsole difference detected for: ${url}\x1b[0m\n` +
-                        `nowprocket console: ${consoleMsgNowprocket}\nactual console: ${consoleMsgActual}`
-                    );
-                }
+        if (consoleMsgActual.length !== 0) {
+            try {
+                expect(consoleMsgActual).toEqual(consoleMsgNowprocket);
+            } catch (e) {
+                throw new Error(
+                    `\x1b[41m\x1b[37mConsole difference detected for: ${url}\x1b[0m\n` +
+                    `nowprocket console: ${consoleMsgNowprocket}\nactual console: ${consoleMsgActual}`
+                );
             }
         }
     }
-
-    if (errors.length > 0) {
-        throw new Error(errors.join('\n\n'));
-    }
-});
+);
 
 
 const getConsoleMsg = async (page: Page, url: string): Promise<Array<string>> => {

--- a/src/support/steps/general.ts
+++ b/src/support/steps/general.ts
@@ -23,6 +23,7 @@ import {
     deactivatePlugin, installRemotePlugin,
 } from "../../../utils/commands";
 import backstop from 'backstopjs';
+import fs from 'fs/promises';
 
 /**
  * Executes the step to log in.
@@ -442,6 +443,63 @@ Then('no error in the console different than nowprocket page {string}', async fu
         expect(consoleMsg2).toEqual(consoleMsg1);
     }
 });
+
+
+/**
+ * Executes the step to check for that there is no console error different from the nowprocket pages version.
+ */
+When('validate that all urls in {string} not having console errors different than nowprocket', async function (this: ICustomWorld, formFactor: string) {
+    let viewPortWidth: number = 1600,
+        viewPortHeight: number = 700,
+        resultFile: string = './src/support/results/expectedResultsDesktop.json',
+        isMobile = 0;
+
+    // Set page to be visited in mobile or for preload fonts
+    if (formFactor === 'mobile') {
+        viewPortWidth = 389;
+        viewPortHeight = 829;
+        resultFile = './src/support/results/expectedResultsMobile.json';
+    } else if (formFactor === 'preloadfonts') {
+        resultFile = './src/support/results/expectedResultsPreloadFonts.json';
+    }
+
+    const data = await fs.readFile(resultFile, 'utf8');
+    const jsonData = JSON.parse(data);
+
+    await this.page.setViewportSize({
+        width: viewPortWidth,
+        height: viewPortHeight
+    });
+
+    const errors: string[] = [];
+
+    for (const key in jsonData) {
+        if (jsonData[key].enabled === true) {
+            const url = `${WP_BASE_URL}/${key}`;
+            const urlNowprocket = `${url}?nowprocket`;
+
+            const consoleMsgNowprocket = await getConsoleMsg(this.page, urlNowprocket);
+            const consoleMsgActual = await getConsoleMsg(this.page, url);
+
+            if (consoleMsgActual.length !== 0) {
+                try {
+                    expect(consoleMsgActual).toEqual(consoleMsgNowprocket);
+                } catch (e) {
+                    // Highlight the URL in the error using ANSI escape codes for color
+                    errors.push(
+                        `\x1b[41m\x1b[37mConsole difference detected for: ${url}\x1b[0m\n` +
+                        `nowprocket console: ${consoleMsgNowprocket}\nactual console: ${consoleMsgActual}`
+                    );
+                }
+            }
+        }
+    }
+
+    if (errors.length > 0) {
+        throw new Error(errors.join('\n\n'));
+    }
+});
+
 
 const getConsoleMsg = async (page: Page, url: string): Promise<Array<string>> => {
     const consoleMsg: string[] = [];

--- a/src/support/steps/general.ts
+++ b/src/support/steps/general.ts
@@ -440,87 +440,16 @@ Then('no error in the console different than nowprocket page {string}', async fu
     const consoleMsg2 = await getConsoleMsg(this.page, `${WP_BASE_URL}/${path}`);
 
     if (consoleMsg2.length !== 0) {
-        expect(consoleMsg2).toEqual(consoleMsg1);
-    }
-});
-
-
-/**
- * Executes the step to check for that there is no console error different from the nowprocket pages version.
- */
-When(
-    "validate that url {string} in {string} does not have console errors different than nowprocket",
-    async function (this: ICustomWorld, templateKey: string, formFactor: string) {
-        let viewPortWidth: number = 1600,
-            viewPortHeight: number = 700,
-            resultFile: string = './src/support/results/expectedResultsDesktop.json';
-
-        if (formFactor === 'mobile') {
-            viewPortWidth = 389;
-            viewPortHeight = 829;
-            resultFile = './src/support/results/expectedResultsMobile.json';
-        } else if (formFactor === 'preloadfonts') {
-            resultFile = './src/support/results/expectedResultsPreloadFonts.json';
-        }
-
-        const data = await fs.readFile(resultFile, 'utf8');
-        const jsonData = JSON.parse(data);
-
-        await this.page.setViewportSize({
-            width: viewPortWidth,
-            height: viewPortHeight
-        });
-
-        // Handle missing/disabled templateKey gracefully
-        if (!jsonData[templateKey] || !jsonData[templateKey].enabled) {
-            throw new Error(`Template key "${templateKey}" not found or not enabled in ${resultFile}`);
-        }
-
-        const url = `${WP_BASE_URL}/${templateKey}`;
-        const urlNowprocket = `${url}?nowprocket`;
-
-        const consoleMsgNowprocket = await getConsoleMsgNoScroll(this.page, urlNowprocket);
-        const consoleMsgActual = await getConsoleMsgNoScroll(this.page, url);
-
-        if (consoleMsgActual.length !== 0) {
-            try {
-                expect(consoleMsgActual).toEqual(consoleMsgNowprocket);
+         try {
+                expect(consoleMsg2).toEqual(consoleMsg1);
             } catch (e) {
                 throw new Error(
-                    `\x1b[41m\x1b[37mConsole difference detected for: ${url}\x1b[0m\n` +
-                    `nowprocket console: ${consoleMsgNowprocket}\nactual console: ${consoleMsgActual}`
+                    `\x1b[41m\x1b[37mConsole difference detected for: ${WP_BASE_URL}/${path}\x1b[0m\n` +
+                    `nowprocket console: ${consoleMsg1}\nactual console: ${consoleMsg2}`
                 );
             }
-        }
     }
-);
-
-const getConsoleMsgNoScroll = async (page: Page, url: string): Promise<Array<string>> => {
-    const consoleMsg: string[] = [];
-
-    const consoleHandler = (msg): void => {
-        consoleMsg.push(msg.text());
-    };
-
-    const pageErrorHandler = (error: Error): void => {
-        consoleMsg.push(error.message);
-    };
-
-    // Listen for console messages.
-    page.on('console', consoleHandler);
-
-    // Listen for page errors.
-    page.on('pageerror', pageErrorHandler);
-
-    await page.goto(url);
-    await page.waitForLoadState('load', { timeout: 30000 });
-
-    // Remove the event listeners to prevent duplicate messages.
-    page.off('console', consoleHandler);
-    page.off('pageerror', pageErrorHandler);
-
-    return consoleMsg;
-}
+});
 
 
 const getConsoleMsg = async (page: Page, url: string): Promise<Array<string>> => {
@@ -543,6 +472,7 @@ const getConsoleMsg = async (page: Page, url: string): Promise<Array<string>> =>
     await page.goto(url);
     await page.waitForLoadState('load', { timeout: 30000 });
 
+    // use this if you need to scroll till end of page
     await page.evaluate(async () => {
         // Scroll to the bottom of page.
         const scrollPage: Promise<void> = new Promise((resolve) => {

--- a/src/support/steps/general.ts
+++ b/src/support/steps/general.ts
@@ -23,7 +23,6 @@ import {
     deactivatePlugin, installRemotePlugin,
 } from "../../../utils/commands";
 import backstop from 'backstopjs';
-import fs from 'fs/promises';
 
 /**
  * Executes the step to log in.

--- a/src/support/steps/lcp-beacon-script.ts
+++ b/src/support/steps/lcp-beacon-script.ts
@@ -132,47 +132,11 @@ When(
         // Visit the page url
         await this.utils.visitPage(templateKey);
 
-        // Wait for beacon attribute before DB check
+        // Wait for beacon attribute 
         await this.page.waitForFunction(() => {
             const beacon = document.querySelector('[data-name="wpr-wpr-beacon"]');
             return beacon && beacon.getAttribute('beacon-completed') === 'true';
         }, { timeout: 100000 });
-
-        if (formFactor !== 'desktop' && formFactor !== 'preloadfonts') {
-            isMobile = 1;
-        }
-
-        // Get the LCP/ATF or Preload Fonts from the DB
-        if (formFactor === 'preloadfonts') {
-            sql = `SELECT fonts FROM ${tablePrefix}wpr_preload_fonts WHERE url LIKE "%${templateKey}%" AND is_mobile = ${isMobile}`;
-        } else {
-            sql = `SELECT lcp, viewport FROM ${tablePrefix}wpr_above_the_fold WHERE url LIKE "%${templateKey}%" AND is_mobile = ${isMobile}`;
-        }
-        const result = await dbQuery(sql);
-        const resultFromStdout = await extractFromStdout(result);
-
-        // If no DB result, set assertion var to false, fail msg and return
-        if (!resultFromStdout || resultFromStdout.length === 0) {
-            isDbResultAvailable = false;
-            failMsg += `No result from database for url ${templateKey} in ${formFactor}\n\n\n`;
-            return;
-        }
-
-        // Populate the actual data.
-        if (formFactor === 'preloadfonts') {
-            actual[templateKey] = {
-                url: url,
-                fonts: resultFromStdout[0].fonts,
-                comment: jsonData[templateKey].comment ?? ''
-            };
-        } else {
-            actual[templateKey] = {
-                url: url,
-                lcp: resultFromStdout[0].lcp,
-                viewport: resultFromStdout[0].viewport,
-                comment: jsonData[templateKey].comment ?? ''
-            };
-        }
     }
 );
 
@@ -265,77 +229,6 @@ When('I visit the urls for {string}', async function (this: ICustomWorld, formFa
 
 });
 
-When(
-    '{string} should be as expected for {string} at {string}',
-    async function (this: ICustomWorld, type: string, formFactor: string, templateKey: string) {
-        // Log fail messages from DB query before failing test.
-        if (failMsg !== '') {
-            console.log('\x1b[31m%s\x1b[0m', failMsg);
-            // Fail test when no DB result is found.
-            expect(isDbResultAvailable).toBeTruthy();
-            return;
-        }
-
-        truthy = true;
-
-        const resultFile: string = './src/support/results/expectedResultsDesktop.json';
-        data = await fs.readFile(resultFile, 'utf8');
-        jsonData = JSON.parse(data);
-
-        // Only check the current templateKey
-        if (!jsonData[templateKey] || !jsonData[templateKey].enabled) {
-            throw new Error(`Template key "${templateKey}" not found or not enabled`);
-        }
-
-        const expected = jsonData[templateKey];
-
-        if (type === 'fonts') {
-            // Compare fonts arrays (containment, not exact match)
-            const expectedFonts = expected.fonts || [];
-            let actualFonts: string[] = [];
-            try {
-                actualFonts = JSON.parse(actual[templateKey].fonts || '[]');
-            } catch (e) {
-                actualFonts = (actual[templateKey].fonts || '').split(',').map(f => f.trim()).filter(Boolean);
-            }
-            for (const font of expectedFonts) {
-                if (!actualFonts.some(actualFont => actualFont.includes(font))) {
-                    truthy = false;
-                    failMsg += `Expected preload font for ${formFactor} - ${font} for ${actual[templateKey].url} is not present in actual - ${actualFonts}\nmore info -- ( ${actual[templateKey].comment} )\n\n\n`;
-                }
-            }
-        } else if (type === 'lcp and atf') {
-            // Run both LCP and ATF logic
-            for (const lcp of expected.lcp) {
-                if (!actual[templateKey].lcp.includes(lcp)) {
-                    truthy = false;
-                    failMsg += `Expected LCP for ${formFactor} - ${lcp} for ${actual[templateKey].url} is not present in actual - ${actual[templateKey].lcp}\nmore info -- ( ${actual[templateKey].comment} )\n\n\n`;
-                    // Highlighted log for missing LCP
-                    console.log('\x1b[43m\x1b[30m[HIGHLIGHTED] LCP MISMATCH for', templateKey, '\x1b[0m');
-                    console.log('\x1b[33mExpected lcp:\x1b[0m', expected.lcp);
-                    console.log('\x1b[36mActual lcp:\x1b[0m', actual[templateKey].lcp);
-                }
-            }
-            for (const viewport of expected.viewport) {
-                if (!actual[templateKey].viewport.includes(viewport)) {
-                    truthy = false;
-                    failMsg += `Expected Viewport for ${formFactor} - ${viewport} for ${actual[templateKey].url} is not present in actual - ${actual[templateKey].viewport}\nmore info -- ( ${actual[templateKey].comment} )\n\n\n`;
-                    // Highlighted log for missing Viewport
-                    console.log('\x1b[41m\x1b[37m[HIGHLIGHTED] VIEWPORT MISMATCH for', templateKey, '\x1b[0m');
-                    console.log('\x1b[33mExpected viewport:\x1b[0m', expected.viewport);
-                    console.log('\x1b[36mActual viewport:\x1b[0m', actual[templateKey].viewport);
-                }
-            }
-        }
-
-        // Log fail message from Expectation mismatch before failing test.
-        if (failMsg !== '') {
-            throw new Error(failMsg);
-        }
-        // Fail test when there is expectation mismatch.
-        expect(truthy).toBeTruthy();
-    }
-);
 
 /**
  * Executes the step to assert that LCP & ATF should be as expected.

--- a/src/support/steps/lcp-beacon-script.ts
+++ b/src/support/steps/lcp-beacon-script.ts
@@ -96,31 +96,18 @@ When(
     'I visit the url {string} for {string}',
     async function (this: ICustomWorld, templateKey: string, formFactor: string) {
         let viewPortWidth: number = 1600,
-            viewPortHeight: number = 700,
-            resultFile: string = './src/support/results/expectedResultsDesktop.json';
+            viewPortHeight: number = 700;
 
         // Set device viewport and result file based on formFactor
         if (formFactor === 'mobile') {
             viewPortWidth = 389;
             viewPortHeight = 829;
-            resultFile = './src/support/results/expectedResultsMobile.json';
-        } else if (formFactor === 'preloadfonts') {
-            resultFile = './src/support/results/expectedResultsPreloadFonts.json';
         }
 
         await this.page.setViewportSize({
             width: viewPortWidth,
             height: viewPortHeight
         });
-
-        const data = await fs.readFile(resultFile, 'utf8');
-        const jsonData = JSON.parse(data);
-
-
-        // Only process one templateKey
-        if (!jsonData[templateKey] || !jsonData[templateKey].enabled) {
-            throw new Error(`Template key "${templateKey}" not found or not enabled in ${resultFile}`);
-        }
 
         // Visit the page url
         await this.utils.visitPage(templateKey);

--- a/src/support/steps/lcp-beacon-script.ts
+++ b/src/support/steps/lcp-beacon-script.ts
@@ -91,6 +91,93 @@ When('I visit the urls and check for lazyload', async function (this: ICustomWor
         }
     }
 });
+
+When(
+    'I visit the url {string} for {string}',
+    async function (this: ICustomWorld, templateKey: string, formFactor: string) {
+        let sql: string,
+            result: string,
+            resultFromStdout: Row[],
+            viewPortWidth: number = 1600,
+            viewPortHeight: number = 700,
+            resultFile: string = './src/support/results/expectedResultsDesktop.json',
+            isMobile = 0;
+
+        // Set device viewport and result file based on formFactor
+        if (formFactor === 'mobile') {
+            viewPortWidth = 389;
+            viewPortHeight = 829;
+            resultFile = './src/support/results/expectedResultsMobile.json';
+        } else if (formFactor === 'preloadfonts') {
+            resultFile = './src/support/results/expectedResultsPreloadFonts.json';
+        }
+
+        failMsg = '';
+
+        await this.page.setViewportSize({
+            width: viewPortWidth,
+            height: viewPortHeight
+        });
+
+        const data = await fs.readFile(resultFile, 'utf8');
+        const jsonData = JSON.parse(data);
+
+        const tablePrefix: string = await getWPTablePrefix();
+
+        // Only process one templateKey
+        if (!jsonData[templateKey] || !jsonData[templateKey].enabled) {
+            throw new Error(`Template key "${templateKey}" not found or not enabled in ${resultFile}`);
+        }
+
+        const url: string = `${WP_BASE_URL}/${templateKey}`;
+
+        // Visit the page url
+        await this.utils.visitPage(templateKey);
+
+        // Wait for beacon attribute before DB check
+        await this.page.waitForFunction(() => {
+            const beacon = document.querySelector('[data-name="wpr-wpr-beacon"]');
+            return beacon && beacon.getAttribute('beacon-completed') === 'true';
+        }, { timeout: 100000 });
+
+        if (formFactor !== 'desktop' && formFactor !== 'preloadfonts') {
+            isMobile = 1;
+        }
+
+        // Get the LCP/ATF or Preload Fonts from the DB
+        if (formFactor === 'preloadfonts') {
+            sql = `SELECT fonts FROM ${tablePrefix}wpr_preload_fonts WHERE url LIKE "%${templateKey}%" AND is_mobile = ${isMobile}`;
+        } else {
+            sql = `SELECT lcp, viewport FROM ${tablePrefix}wpr_above_the_fold WHERE url LIKE "%${templateKey}%" AND is_mobile = ${isMobile}`;
+        }
+        result = await dbQuery(sql);
+        resultFromStdout = await extractFromStdout(result);
+
+        // If no DB result, set assertion var to false, fail msg and return
+        if (!resultFromStdout || resultFromStdout.length === 0) {
+            isDbResultAvailable = false;
+            failMsg += `No result from database for url ${templateKey} in ${formFactor}\n\n\n`;
+            return;
+        }
+
+        // Populate the actual data.
+        if (formFactor === 'preloadfonts') {
+            actual[templateKey] = {
+                url: url,
+                fonts: resultFromStdout[0].fonts,
+                comment: jsonData[templateKey].comment ?? ''
+            };
+        } else {
+            actual[templateKey] = {
+                url: url,
+                lcp: resultFromStdout[0].lcp,
+                viewport: resultFromStdout[0].viewport,
+                comment: jsonData[templateKey].comment ?? ''
+            };
+        }
+    }
+);
+
 /**
  * Executes step to visit page based on the form factor(desktop/mobile) and get the LCP/ATF data from DB.
  */
@@ -179,6 +266,74 @@ When('I visit the urls for {string}', async function (this: ICustomWorld, formFa
     }
 
 });
+
+Then(
+    '{string} should be as expected for {string} at {string}',
+    async function (this: ICustomWorld, type: string, formFactor: string, templateKey: string) {
+        // Log fail messages from DB query before failing test.
+        if (failMsg !== '') {
+            console.log('\x1b[31m%s\x1b[0m', failMsg);
+            // Fail test when no DB result is found.
+            expect(isDbResultAvailable).toBeTruthy();
+            return;
+        }
+
+        truthy = true;
+
+        // Only check the current templateKey
+        if (!jsonData[templateKey] || !jsonData[templateKey].enabled) {
+            throw new Error(`Template key "${templateKey}" not found or not enabled`);
+        }
+
+        const expected = jsonData[templateKey];
+
+        if (type === 'fonts') {
+            // Compare fonts arrays (containment, not exact match)
+            const expectedFonts = expected.fonts || [];
+            let actualFonts: string[] = [];
+            try {
+                actualFonts = JSON.parse(actual[templateKey].fonts || '[]');
+            } catch (e) {
+                actualFonts = (actual[templateKey].fonts || '').split(',').map(f => f.trim()).filter(Boolean);
+            }
+            for (const font of expectedFonts) {
+                if (!actualFonts.some(actualFont => actualFont.includes(font))) {
+                    truthy = false;
+                    failMsg += `Expected preload font for ${formFactor} - ${font} for ${actual[templateKey].url} is not present in actual - ${actualFonts}\nmore info -- ( ${actual[templateKey].comment} )\n\n\n`;
+                }
+            }
+        } else if (type === 'lcp and atf') {
+            // Run both LCP and ATF logic
+            for (const lcp of expected.lcp) {
+                if (!actual[templateKey].lcp.includes(lcp)) {
+                    truthy = false;
+                    failMsg += `Expected LCP for ${formFactor} - ${lcp} for ${actual[templateKey].url} is not present in actual - ${actual[templateKey].lcp}\nmore info -- ( ${actual[templateKey].comment} )\n\n\n`;
+                    // Highlighted log for missing LCP
+                    console.log('\x1b[43m\x1b[30m[HIGHLIGHTED] LCP MISMATCH for', templateKey, '\x1b[0m');
+                    console.log('\x1b[33mExpected lcp:\x1b[0m', expected.lcp);
+                    console.log('\x1b[36mActual lcp:\x1b[0m', actual[templateKey].lcp);
+                }
+            }
+            for (const viewport of expected.viewport) {
+                if (!actual[templateKey].viewport.includes(viewport)) {
+                    truthy = false;
+                    failMsg += `Expected Viewport for ${formFactor} - ${viewport} for ${actual[templateKey].url} is not present in actual - ${actual[templateKey].viewport}\nmore info -- ( ${actual[templateKey].comment} )\n\n\n`;
+                    // Highlighted log for missing Viewport
+                    console.log('\x1b[41m\x1b[37m[HIGHLIGHTED] VIEWPORT MISMATCH for', templateKey, '\x1b[0m');
+                    console.log('\x1b[33mExpected viewport:\x1b[0m', expected.viewport);
+                    console.log('\x1b[36mActual viewport:\x1b[0m', actual[templateKey].viewport);
+                }
+            }
+        }
+
+        // Log fail message from Expectation mismatch before failing test.
+        if (failMsg !== '') {
+            throw new Error(failMsg);
+        }
+        // Fail test when there is expectation mismatch.
+        expect(truthy).toBeTruthy();
+    }
+);
 
 /**
  * Executes the step to assert that LCP & ATF should be as expected.

--- a/src/support/steps/lcp-beacon-script.ts
+++ b/src/support/steps/lcp-beacon-script.ts
@@ -95,11 +95,9 @@ When('I visit the urls and check for lazyload', async function (this: ICustomWor
 When(
     'I visit the url {string} for {string}',
     async function (this: ICustomWorld, templateKey: string, formFactor: string) {
-        let sql: string,
-            viewPortWidth: number = 1600,
+        let viewPortWidth: number = 1600,
             viewPortHeight: number = 700,
-            resultFile: string = './src/support/results/expectedResultsDesktop.json',
-            isMobile = 0;
+            resultFile: string = './src/support/results/expectedResultsDesktop.json';
 
         // Set device viewport and result file based on formFactor
         if (formFactor === 'mobile') {
@@ -110,8 +108,6 @@ When(
             resultFile = './src/support/results/expectedResultsPreloadFonts.json';
         }
 
-        failMsg = '';
-
         await this.page.setViewportSize({
             width: viewPortWidth,
             height: viewPortHeight
@@ -120,14 +116,11 @@ When(
         const data = await fs.readFile(resultFile, 'utf8');
         const jsonData = JSON.parse(data);
 
-        const tablePrefix: string = await getWPTablePrefix();
 
         // Only process one templateKey
         if (!jsonData[templateKey] || !jsonData[templateKey].enabled) {
             throw new Error(`Template key "${templateKey}" not found or not enabled in ${resultFile}`);
         }
-
-        const url: string = `${WP_BASE_URL}/${templateKey}`;
 
         // Visit the page url
         await this.utils.visitPage(templateKey);

--- a/src/support/steps/lcp-beacon-script.ts
+++ b/src/support/steps/lcp-beacon-script.ts
@@ -96,8 +96,6 @@ When(
     'I visit the url {string} for {string}',
     async function (this: ICustomWorld, templateKey: string, formFactor: string) {
         let sql: string,
-            result: string,
-            resultFromStdout: Row[],
             viewPortWidth: number = 1600,
             viewPortHeight: number = 700,
             resultFile: string = './src/support/results/expectedResultsDesktop.json',
@@ -150,8 +148,8 @@ When(
         } else {
             sql = `SELECT lcp, viewport FROM ${tablePrefix}wpr_above_the_fold WHERE url LIKE "%${templateKey}%" AND is_mobile = ${isMobile}`;
         }
-        result = await dbQuery(sql);
-        resultFromStdout = await extractFromStdout(result);
+        const result = await dbQuery(sql);
+        const resultFromStdout = await extractFromStdout(result);
 
         // If no DB result, set assertion var to false, fail msg and return
         if (!resultFromStdout || resultFromStdout.length === 0) {

--- a/src/support/steps/lcp-beacon-script.ts
+++ b/src/support/steps/lcp-beacon-script.ts
@@ -267,7 +267,7 @@ When('I visit the urls for {string}', async function (this: ICustomWorld, formFa
 
 });
 
-Then(
+When(
     '{string} should be as expected for {string} at {string}',
     async function (this: ICustomWorld, type: string, formFactor: string, templateKey: string) {
         // Log fail messages from DB query before failing test.
@@ -279,6 +279,10 @@ Then(
         }
 
         truthy = true;
+
+        const resultFile: string = './src/support/results/expectedResultsDesktop.json';
+        data = await fs.readFile(resultFile, 'utf8');
+        jsonData = JSON.parse(data);
 
         // Only check the current templateKey
         if (!jsonData[templateKey] || !jsonData[templateKey].enabled) {

--- a/utils/page-utils.ts
+++ b/utils/page-utils.ts
@@ -87,6 +87,13 @@ export class PageUtils {
 
         // Click login.
         await this.page.click('#wp-submit');
+        
+        // Confirm login worked
+        await this.page.waitForURL('**/wp-admin/**', { timeout: 5000 });
+
+        if (!this.page.url().includes('/wp-admin')) {
+            throw new Error('❌ Login failed: User not redirected to dashboard.');
+        }
     }
 
     /**

--- a/utils/page-utils.ts
+++ b/utils/page-utils.ts
@@ -82,12 +82,17 @@ export class PageUtils {
         // Fill username & password.
         await this.page.click('#user_login');
         await this.page.fill('#user_login', username);
+        // Confirm username is filled correctly
+        await expect(this.page.locator('#user_login')).toHaveValue(username);
+
         await this.page.click('#user_pass');
         await this.page.fill('#user_pass', password);
+        // Confirm password is filled correctly
+        await expect(this.page.locator('#user_pass')).toHaveValue(password);
 
         // Click login.
         await this.page.click('#wp-submit');
-        
+
         // Confirm login worked
         await this.page.waitForURL('**/wp-admin/**', { timeout: 5000 });
 


### PR DESCRIPTION
# Description
The test will fail if a new console error appears after applying LCP.

Fixes #259 , #190

*Explain how this code impacts users.*
With this PR, if the LCP image was written in the wrong format, causing a 404 image, we will know from the e2e results

## Type of change

- [ ] New feature (non-breaking change which adds functionality).
- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] Enhancement (non-breaking change which improves an existing functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as before).
- [ ] Sub-task of #(issue number)
- [ ] Chore
- [ ] Release

## Detailed scenario

### What was tested

Run Scenario while the template causing the error is on => the error will be there in the Cucumber report
<img width="1815" height="1002" alt="Screenshot from 2025-09-02 16-58-14" src="https://github.com/user-attachments/assets/8155a81d-d62c-41e3-a9df-f3144018d0e6" />

Run Scenario  while the template causing error is off => all green (didn't add template in scenario outline if it's failing)
<img width="1815" height="1002" alt="Screenshot from 2025-09-02 11-07-15" src="https://github.com/user-attachments/assets/78813373-c254-4c8a-86cd-111e3737a36d" />


### How to test
Run LCP => tests should be green if the template causing console error is off, otherwise the error will be there in the cucumber report

## Technical description

### Documentation

- It compares the console error of the cached pages vs nowprocket, and if there is a difference, an error will be logged
- Code could be refactored later so we can check console error after applying any feature, now it covers lcp and preloadfonts in steps, while used only in lcp
- It should fail for ` lcp_bg_responsive_webkit_template `, need investigation how it passes (probably as the warning takes time to show in console)

### New dependencies

N/A

### Risks

N/A

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [ ] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [ ] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [ ] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionable.

## Unticked items justification

N/A
# Additional Checks
- [x] In the case of complex code, I wrote comments to explain it.
- [x] When possible, I prepared ways to observe the implemented system (logs, data, etc.).
- [ ] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.)
