### PR TITLE
E2E - Fixed some wrong tags and added a new one to run only backwpup tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "wp-env": "wp-env",
     "test:bwpupstorage": "$npm_package_config_testCommand --tags @bwpupstorage",
     "test:bwpuponboarding": "$npm_package_config_testCommand --tags @bwpuponboarding",
-    "test:bwpupsmoke": "$npm_package_config_testCommand --tags @bwpupsmoke"
+    "test:bwpupsmoke": "$npm_package_config_testCommand --tags @bwpupsmoke",
+    "test:bwpup": "$npm_package_config_testCommand --tags @bwpup"
   },
   "repository": {
     "type": "git",

--- a/src/backwpup/features/backup.feature
+++ b/src/backwpup/features/backup.feature
@@ -1,4 +1,4 @@
-@bwpupsetup @bwpupsmoke
+@bwpup @bwpupsetup @bwpupsmoke
 Feature: Should be able to backup
 
   Background:

--- a/src/backwpup/features/delete-plugin.feature
+++ b/src/backwpup/features/delete-plugin.feature
@@ -1,4 +1,4 @@
-@bwpsetup @bwpplugindeletion @bwpupsmoke
+@bwpup @bwpupsetup @bwpupplugindeletion @bwpupsmoke
 Feature: Should successfully delete BackWPup plugin
 
     Background:

--- a/src/backwpup/features/download-restore.feature
+++ b/src/backwpup/features/download-restore.feature
@@ -1,4 +1,4 @@
-@bwupsetup @bwupdownload @bwupsmoke
+@bwpup @bwpupsetup @bwpupdownload @bwpupsmoke
 Feature: BackWPUp Download backup
     Background:
         Given I am logged in

--- a/src/backwpup/features/onboarding.feature
+++ b/src/backwpup/features/onboarding.feature
@@ -1,4 +1,4 @@
-@bwpupsetup @bwpupsmoke
+@bwpup @bwpupsetup @bwpupsmoke
 Feature: BackWpUp Onboarding
 
   Background:

--- a/src/backwpup/features/storages/ftp.feature
+++ b/src/backwpup/features/storages/ftp.feature
@@ -1,4 +1,4 @@
-@bwupsetup @bwpupstorage @bwpupsmoke @bwpupstorageftp
+@bwpup @bwpupsetup @bwpupstorage @bwpupsmoke @bwpupstorageftp
 
 Feature: Should be able to work with FTP storage
   Background:

--- a/src/backwpup/features/storages/msazure.feature
+++ b/src/backwpup/features/storages/msazure.feature
@@ -1,4 +1,4 @@
-@bwupsetup @bwpupstorage @bwpupsmoke @bwpupstoragemsazure
+@bwpup @bwpupsetup @bwpupstorage @bwpupsmoke @bwpupstoragemsazure
 
 Feature: Should be able to work with Microsoft Azure storage
 


### PR DESCRIPTION
# Description

Just a small change that fixes the wrong tags, and added one new tag to all tests to be able to run all tests with one tag

New tag: `@bwpup`

To run with:
`node ./node_modules/@cucumber/cucumber/bin/cucumber-js -p default --tags @bwpup`

## Type of change

- [ ] New feature (non-breaking change which adds functionality).
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] Enhancement (non-breaking change which improves an existing functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as before).
- [ ] Sub-task of #(issue number)
- [ ] Chore
- [ ] Release

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style
n/a
## Unticked items justification
n/a
