### PR TITLE
fixed data selection in "I uncheck the {string} from files backup option" like steps

### DIFF
--- a/src/backwpup/steps/onboarding.ts
+++ b/src/backwpup/steps/onboarding.ts
@@ -118,8 +118,10 @@ Then('all database tables should be selected', async function (this: ICustomWorl
 
 When('I uncheck the {string} from files backup option', async function (this: ICustomWorld, value: string) {
     await this.page.locator('button[data-content="select-files"][data-job-id="1"]').click();
+    await this.page.waitForSelector('#sidebar-select-files', { state: 'visible' });
 
     const checkbox = this.page.locator(`label:has(input[name="${value}"])`);
+    await checkbox.scrollIntoViewIfNeeded();
     const isChecked = await checkbox.isChecked();
 
     if (isChecked) {
@@ -128,12 +130,15 @@ When('I uncheck the {string} from files backup option', async function (this: IC
 
     await expect(checkbox).not.toBeChecked();
     await this.page.locator('button#file-exclusions-submit').click();
+    await expect(this.page.locator('#sidebar-select-files')).not.toBeInViewport();
 });
 
 When('I uncheck the {string} from database backup option', async function (this: ICustomWorld, value: string) {
     await this.page.locator('button[data-content="select-tables"][data-job-id="1"]').click();
+    await this.page.waitForSelector('#sidebar-select-tables', { state: 'visible' });
 
     const checkbox = this.page.locator(`label:has(input[value="${value}"])`);
+    await checkbox.scrollIntoViewIfNeeded();
     const isChecked = await checkbox.isChecked();
 
     if (isChecked) {
@@ -142,6 +147,7 @@ When('I uncheck the {string} from database backup option', async function (this:
 
     await expect(checkbox).not.toBeChecked();
     await this.page.locator('button#save-excluded-tables').click();
+    await expect(this.page.locator('#sidebar-select-tables')).not.toBeInViewport();
 });
 
 const validateCheckboxSelection = async (page: Page, containerSelector: string, shouldBeChecked: boolean = true): Promise<void> => {


### PR DESCRIPTION
# Description

Fixes #270

Fixes issue when some selectors are not available on screen.

## Type of change

- [ ] New feature (non-breaking change which adds functionality).
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] Enhancement (non-breaking change which improves an existing functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as before).
- [ ] Sub-task of #(issue number)
- [ ] Chore
- [ ] Release

## Detailed scenario

### What was tested

Scenario: Should respect data selection

<img width="404" height="74" alt="image" src="https://github.com/user-attachments/assets/6d8df7bc-0151-4542-848c-ff33f528c5a2" />

### How to test

node ./node_modules/@cucumber/cucumber/bin/cucumber-js -p default --name "Should respect data selection"

## Technical description

### Documentation

Awaits for some necessary selectors to be available for the test to not fail

### New dependencies

*List any new dependencies that are required for this change.*

### Risks

*List possible performance & security issues or risks, and explain how they have been mitigated.*

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification

n/a
