### PR TITLE
replaced wp cli uninstallation with UI uninstallation for BWU tests

### DIFF
--- a/src/backwpup/steps/delete.ts
+++ b/src/backwpup/steps/delete.ts
@@ -16,18 +16,8 @@ import { When, Then } from '@cucumber/cucumber';
  * Executes the step to delete the WP Rocket plugin.
  */
 When('I delete backwpup plugin', async function (this: ICustomWorld) {
-    // Goto plugins page.
-    await this.utils.gotoPlugin();
-
-    // Ensure BWU is deactivated.
-    await this.utils.togglePluginActivation('backwpup-pro', false);
-
-    // Check for deactivation modal.
-    if (await this.page.locator('label[for=deactivate]').isVisible()) {
-        await this.page.locator('label[for=deactivate]').click();
-        await this.page.locator('text=Confirm').click();
-    }
-
+    // Deactivate BWU
+    await this.utils.deactivateBackWpViaUi();
     // Delete BWU.
     await this.utils.removeBackWpViaUi();
 });

--- a/src/backwpup/support/hooks.ts
+++ b/src/backwpup/support/hooks.ts
@@ -5,7 +5,7 @@ import { PageUtils } from "../../../utils/page-utils";
 import { Before, After} from "@cucumber/cucumber";
 import {StorageUtils} from "../utils/storage";
 import {configurations} from "../../../utils/configurations";
-import {rm, testSshConnection, uninstallPlugin} from "../../../utils/commands";
+import {rm, testSshConnection} from "../../../utils/commands";
 import {WP_SSH_ROOT_DIR} from "../../../config/wp.config";
 import {Page} from "@playwright/test";
 
@@ -36,7 +36,9 @@ After(async function (this: ICustomWorld) {
         const backwpupRestoreFolder = `${WP_SSH_ROOT_DIR}wp-content/uploads/backwpup-restore`;
         await rm(backwpupRestoreFolder);
 
-        await uninstallPlugin('backwpup-pro');
+        // Remove BackWPup plugin
+        await this.utils.deactivateBackWpViaUi();
+        await this.utils.removeBackWpViaUi();
     } catch (error) {
         console.error('Setup failed: ', error.message);
         throw new Error('Setup failed: ' + error.message);

--- a/utils/page-utils.ts
+++ b/utils/page-utils.ts
@@ -619,7 +619,19 @@ export class PageUtils {
             await this.removeWprViaUi();
         }
     }
+    public deactivateBackWpViaUi = async (): Promise<void> => {
+        // Goto plugins page.
+        await this.gotoPlugin();
 
+        // Ensure BWU is deactivated.
+        await this.togglePluginActivation('backwpup-pro', false);
+
+        // Check for deactivation modal.
+        if (await this.page.locator('label[for=deactivate]').isVisible()) {
+            await this.page.locator('label[for=deactivate]').click();
+            await this.page.locator('text=Confirm').click();
+        }
+    }
     public removeBackWpViaUi = async (): Promise<void> => {
         await this.gotoPlugin();
 


### PR DESCRIPTION
# Description

Fixes #272

BackWPup uninstallation is fixed

## Type of change

- [ ] New feature (non-breaking change which adds functionality).
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] Enhancement (non-breaking change which improves an existing functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as before).
- [ ] Sub-task of #(issue number)
- [ ] Chore
- [ ] Release

## Detailed scenario

### What was tested

The uninstallation of the plugin in an `after` hook

### How to test

`node ./node_modules/@cucumber/cucumber/bin/cucumber-js -p default --tags @bwpupsmoke`

## Technical description

### Documentation

Replaced wp cli plugin installation with UI equivalent

### New dependencies

*List any new dependencies that are required for this change.*

### Risks

*List possible performance & security issues or risks, and explain how they have been mitigated.*

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification
n/a