### PR TITLE
Fix/281 use bwpu cleanup only for bwpu test

### DIFF
--- a/src/backwpup/support/hooks.ts
+++ b/src/backwpup/support/hooks.ts
@@ -26,7 +26,7 @@ Before({tags: '@bwpupsetup'}, async function(this: ICustomWorld, {pickle}) {
 /**
  * After every test, delete data
  */
-After(async function (this: ICustomWorld) {
+After({ tags: '@bwpup' }, async function (this: ICustomWorld) {
     await deleteAllData(this.page);
     try {
         await testSshConnection();

--- a/src/backwpup/support/hooks.ts
+++ b/src/backwpup/support/hooks.ts
@@ -35,6 +35,9 @@ After(async function (this: ICustomWorld) {
         await rm(backwpupFolder);
         const backwpupRestoreFolder = `${WP_SSH_ROOT_DIR}wp-content/uploads/backwpup-restore`;
         await rm(backwpupRestoreFolder);
+        // Remove any BackWPup plugin zip files that may have been uploaded during tests.
+        const backwpupPluginZips = `${WP_SSH_ROOT_DIR}wp-content/uploads/**/**/backwpup-pro*.zip`;
+        await rm(backwpupPluginZips);
 
         // Remove BackWPup plugin
         await this.utils.deactivateBackWpViaUi();


### PR DESCRIPTION
# Description

Fixes #281

This will prevent BackWPup clearing hook to be executed when WP Rocket tests run.

Also, it will remove `backwpup-pro*.zip` files (leftovers) on upload directory, to prevent site from growing and making the backups to increase size. 

## Type of change

- [ ] New feature (non-breaking change which adds functionality).
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] Enhancement (non-breaking change which improves an existing functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as before).
- [ ] Sub-task of #(issue number)
- [ ] Chore
- [ ] Release

## Detailed scenario

### What was tested

The backwpup clearing hook not being executed on WP Rocket tests, and leftovers zip files are removed.

### How to test

Run WP Rocket test and see that clearing hook is not triggered

## Technical description

### Documentation

It simply adds tag to BackWPup clearing hook and use rm to remove zip leftovers

### New dependencies

N/A

### Risks

N/A

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification

*If some mandatory items are not relevant, explain why in this section.*

# Additional Checks
- [ ] In the case of complex code, I wrote comments to explain it.
- [ ] When possible, I prepared ways to observe the implemented system (logs, data, etc.).
- [ ] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.)
