### PR TITLE
fix dialog handling error

### DIFF
--- a/utils/page-utils.ts
+++ b/utils/page-utils.ts
@@ -652,14 +652,13 @@ export class PageUtils {
             await this.page.locator('text=Confirm').click();
         }
 
+        await this.page.waitForLoadState('load', { timeout: 30000 });
 
-        this.page.on('dialog', async(dialog) => {
+        this.page.once('dialog', async(dialog) => {
             expect(dialog.type()).toContain('confirm');
             expect(dialog.message()).toContain('Are you sure you want to delete BackWPup Pro and its data?');
             await dialog.accept();
         });
-
-        await this.page.waitForLoadState('load', { timeout: 30000 });
 
         await this.page.locator( '#delete-backwpup-pro' ).click();
 

--- a/utils/page-utils.ts
+++ b/utils/page-utils.ts
@@ -654,7 +654,7 @@ export class PageUtils {
 
         await this.page.waitForLoadState('load', { timeout: 30000 });
 
-        this.page.once('dialog', async(dialog) => {
+        this.page.once('dialog', async (dialog) => {
             expect(dialog.type()).toContain('confirm');
             expect(dialog.message()).toContain('Are you sure you want to delete BackWPup Pro and its data?');
             await dialog.accept();


### PR DESCRIPTION
# Description

Listen to dialog event only once to prevent multiple listeners to be assigned

## Type of change

- [ ] New feature (non-breaking change which adds functionality).
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] Enhancement (non-breaking change which improves an existing functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as before).
- [ ] Sub-task of #(issue number)
- [ ] Chore
- [ ] Release

## Detailed scenario

### What was tested

Ran the whole suite for BackWPup 5 times with: `for i in $(seq 1 5); do npm run test:bwpup; done` and couln't see this any error about dialog handling.

<img width="749" height="421" alt="image" src="https://github.com/user-attachments/assets/4fcea16c-3252-462a-af3e-9ca936e84f48" />

### How to test

Run: `for i in $(seq 1 5); do npm run test:bwpup; done`

## Technical description

### Documentation

Changed the `page.on('dialog'...` to `page.once('dialog'...`.

### New dependencies

N/A

### Risks

N/A

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification

*If some mandatory items are not relevant, explain why in this section.*

# Additional Checks
- [ ] In the case of complex code, I wrote comments to explain it.
- [ ] When possible, I prepared ways to observe the implemented system (logs, data, etc.).
- [ ] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.)
