### PR TITLE
Extend enable-all settings step to validate text inputs

### DIFF
--- a/src/features/enable-all-features.feature
+++ b/src/features/enable-all-features.feature
@@ -9,7 +9,7 @@ Feature: C1205 - Enabling all WP Rocket features should not throw any fatal erro
     Scenario: Enable all features
         When I go to 'wp-admin/options-general.php?page=wprocket#dashboard'
         And I enable all settings
-        And I enable all settings with text inputs
+        # And I enable all settings with text inputs
         And I log out
         Then page loads successfully
         When I log in

--- a/src/features/enable-all-features.feature
+++ b/src/features/enable-all-features.feature
@@ -8,6 +8,7 @@ Feature: C1205 - Enabling all WP Rocket features should not throw any fatal erro
 
     Scenario: Enable all features
         When I go to 'wp-admin/options-general.php?page=wprocket#dashboard'
+        And I enable all settings
         And I enable all settings with text inputs
         And I log out
         Then page loads successfully

--- a/src/features/enable-all-features.feature
+++ b/src/features/enable-all-features.feature
@@ -1,4 +1,4 @@
-@smoke @local @setup
+@smoke @local @setup 
 Feature: C1205 - Enabling all WP Rocket features should not throw any fatal errors
 
     Background:
@@ -8,7 +8,7 @@ Feature: C1205 - Enabling all WP Rocket features should not throw any fatal erro
 
     Scenario: Enable all features
         When I go to 'wp-admin/options-general.php?page=wprocket#dashboard'
-        And I enable all settings
+        And I enable all settings with text inputs
         And I log out
         Then page loads successfully
         When I log in

--- a/src/features/enable-all-features.feature
+++ b/src/features/enable-all-features.feature
@@ -1,4 +1,4 @@
-@smoke @local @setup 
+@smoke @local @setup
 Feature: C1205 - Enabling all WP Rocket features should not throw any fatal errors
 
     Background:

--- a/src/support/steps/general.ts
+++ b/src/support/steps/general.ts
@@ -246,6 +246,13 @@ When('I enable all settings', async function (this: ICustomWorld) {
 });
 
 /**
+ * Executes the step to enable all settings and validates text inputs.
+ */
+When('I enable all settings with text inputs', async function (this: ICustomWorld) {
+    await this.utils.enableAllOptionsWithTextInputs();
+});
+
+/**
  * Executes the step to log out.
  */
 When('I log out', async function (this: ICustomWorld) {

--- a/utils/page-utils.ts
+++ b/utils/page-utils.ts
@@ -600,7 +600,7 @@ export class PageUtils {
             'heartbeat',
             'addons',
         ];
-        const allowedInputTypes = new Set(['', 'text', 'search', 'url', 'email']);
+        const allowedInputTypes = new Set(['', 'text', 'search', 'url']);
         const dialogMessages: string[] = [];
         let activeField = '';
 

--- a/utils/page-utils.ts
+++ b/utils/page-utils.ts
@@ -605,7 +605,7 @@ export class PageUtils {
         let activeField = '';
 
         await this.gotoWpr();
-        await this.suppressSettingsFormSubmit();
+        await this.preventSettingsFormSubmission();
 
         const handleDialog = async (dialog: Dialog): Promise<void> => {
             dialogMessages.push(`${dialog.message()}${activeField ? ` (Field: ${activeField})` : ''}`);
@@ -661,7 +661,7 @@ export class PageUtils {
         } finally {
             this.page.off('dialog', handleDialog);
             activeField = '';
-            await this.resumeSettingsFormSubmit();
+            await this.allowSettingsFormSubmission();
         }
 
         if (dialogMessages.length > 0) {
@@ -674,7 +674,7 @@ export class PageUtils {
      *
      * @return {Promise<void>}
      */
-    private suppressSettingsFormSubmit = async (): Promise<void> => {
+    private preventSettingsFormSubmission = async (): Promise<void> => {
         await this.page.waitForSelector('form[id$="_options"]');
         await this.page.evaluate(() => {
             const form = document.querySelector('form[id$="_options"]');
@@ -697,7 +697,7 @@ export class PageUtils {
      *
      * @return {Promise<void>}
      */
-    private resumeSettingsFormSubmit = async (): Promise<void> => {
+    private allowSettingsFormSubmission = async (): Promise<void> => {
         await this.page.evaluate(() => {
             const form = document.querySelector('form[id$="_options"]');
             const win = window as typeof window & { wprSubmitInterceptor?: (event: Event) => void };

--- a/utils/page-utils.ts
+++ b/utils/page-utils.ts
@@ -664,9 +664,10 @@ export class PageUtils {
             await this.allowSettingsFormSubmission();
         }
 
-        if (dialogMessages.length > 0) {
-            throw new Error(`Unexpected validation dialog(s) triggered while interacting with text inputs: ${dialogMessages.join(' | ')}`);
-        }
+        expect(
+            dialogMessages,
+            `Unexpected validation dialog(s) triggered while interacting with text inputs: ${dialogMessages.join(' | ')}`
+        ).toHaveLength(0);
     }
 
     /**

--- a/utils/page-utils.ts
+++ b/utils/page-utils.ts
@@ -678,17 +678,17 @@ export class PageUtils {
         await this.page.waitForSelector('form[id$="_options"]');
         await this.page.evaluate(() => {
             const form = document.querySelector('form[id$="_options"]');
-            const win = window as typeof window & { __wprSubmitInterceptor?: (event: Event) => void };
+            const win = window as typeof window & { wprSubmitInterceptor?: (event: Event) => void };
 
-            if (!form || win.__wprSubmitInterceptor) {
+            if (!form || win.wprSubmitInterceptor) {
                 return;
             }
 
-            win.__wprSubmitInterceptor = (event: Event) => {
+            win.wprSubmitInterceptor = (event: Event): void => {
                 event.preventDefault();
             };
 
-            form.addEventListener('submit', win.__wprSubmitInterceptor, true);
+            form.addEventListener('submit', win.wprSubmitInterceptor, true);
         });
     }
 
@@ -700,14 +700,14 @@ export class PageUtils {
     private resumeSettingsFormSubmit = async (): Promise<void> => {
         await this.page.evaluate(() => {
             const form = document.querySelector('form[id$="_options"]');
-            const win = window as typeof window & { __wprSubmitInterceptor?: (event: Event) => void };
+            const win = window as typeof window & { wprSubmitInterceptor?: (event: Event) => void };
 
-            if (!form || !win.__wprSubmitInterceptor) {
+            if (!form || !win.wprSubmitInterceptor) {
                 return;
             }
 
-            form.removeEventListener('submit', win.__wprSubmitInterceptor, true);
-            delete win.__wprSubmitInterceptor;
+            form.removeEventListener('submit', win.wprSubmitInterceptor, true);
+            delete win.wprSubmitInterceptor;
         });
     }
 

--- a/utils/page-utils.ts
+++ b/utils/page-utils.ts
@@ -8,9 +8,9 @@
  * @requires {@link ../config/wp.config}
  * @requires {@link ./configurations}
  */
-import type {Page} from '@playwright/test';
+import type { Dialog, Page } from '@playwright/test';
 import type {Sections} from '../src/common/sections';
-import type {Locators, Selector, Pickle} from './types';
+import type {Locators, Selector, Pickle, SectionId} from './types';
 import {expect} from "@playwright/test";
 import { ICustomWorld } from '../src/common/custom-world';
 import fs from "fs/promises";
@@ -565,6 +565,150 @@ export class PageUtils {
         }
 
     
+    }
+
+    /**
+     * Enables all options and ensures every visible text input accepts arbitrary values without native validation dialogs.
+     *
+     * @return {Promise<void>}
+     */
+    public enableAllOptionsWithTextInputs = async (): Promise<void> => {
+        await this.enableAllOptions();
+        await this.validateTextInputsWithoutDialogs();
+    }
+
+    /**
+     * Iterates over every visible text field in each section, types a test value, presses Enter,
+     * and fails if a browser dialog appears (e.g. "Please enter a valid URL").
+     *
+     * The original field values are restored after each check, and form submissions are suppressed to avoid unwanted saves.
+     *
+     * @param {string} testValue - Value to use while validating the inputs.
+     *
+     * @return {Promise<void>}
+     */
+    private validateTextInputsWithoutDialogs = async (testValue: string = 'test'): Promise<void> => {
+        const sectionIds: SectionId[] = [
+            'dashboard',
+            'cache',
+            'file_optimization',
+            'media',
+            'preload',
+            'advanced_cache',
+            'database',
+            'page_cdn',
+            'heartbeat',
+            'addons',
+        ];
+        const allowedInputTypes = new Set(['', 'text', 'search', 'url', 'email']);
+        const dialogMessages: string[] = [];
+        let activeField = '';
+
+        await this.gotoWpr();
+        await this.suppressSettingsFormSubmit();
+
+        const handleDialog = async (dialog: Dialog): Promise<void> => {
+            dialogMessages.push(`${dialog.message()}${activeField ? ` (Field: ${activeField})` : ''}`);
+            await dialog.dismiss();
+        };
+
+        this.page.on('dialog', handleDialog);
+
+        try {
+            for (const sectionId of sectionIds) {
+                const navLocator = this.page.locator(`#wpr-nav-${sectionId}`);
+                if (!await navLocator.isVisible()) {
+                    continue;
+                }
+
+                await navLocator.scrollIntoViewIfNeeded();
+                await navLocator.click();
+                await this.page.locator(`#${sectionId}`).waitFor({ state: 'visible' });
+
+                const textInputs = this.page
+                    .locator(`#${sectionId}`)
+                    .locator('textarea, input[type="text"], input[type="search"], input[type="url"], input:not([type])');
+
+                const fieldCount = await textInputs.count();
+
+                for (let index = 0; index < fieldCount; index++) {
+                    const field = textInputs.nth(index);
+
+                    if (!await field.isVisible() || await field.isDisabled() || !await field.isEditable()) {
+                        continue;
+                    }
+
+                    const tagName = await field.evaluate((el) => el.tagName.toLowerCase());
+                    if (tagName === 'input') {
+                        const typeAttr = (await field.getAttribute('type'))?.toLowerCase() ?? '';
+                        if (!allowedInputTypes.has(typeAttr)) {
+                            continue;
+                        }
+                    }
+
+                    const fieldId = await field.getAttribute('id');
+                    const fieldName = await field.getAttribute('name');
+                    activeField = `${sectionId}:${fieldId ?? fieldName ?? `field-${index}`}`;
+
+                    const originalValue = await field.inputValue();
+
+                    await field.fill(testValue);
+                    await field.press('Enter', { noWaitAfter: true });
+                    await this.page.waitForTimeout(100);
+                    await field.fill(originalValue);
+                }
+            }
+        } finally {
+            this.page.off('dialog', handleDialog);
+            activeField = '';
+            await this.resumeSettingsFormSubmit();
+        }
+
+        if (dialogMessages.length > 0) {
+            throw new Error(`Unexpected validation dialog(s) triggered while interacting with text inputs: ${dialogMessages.join(' | ')}`);
+        }
+    }
+
+    /**
+     * Prevents the WP Rocket settings form from submitting while we simulate Enter presses on inputs.
+     *
+     * @return {Promise<void>}
+     */
+    private suppressSettingsFormSubmit = async (): Promise<void> => {
+        await this.page.waitForSelector('form[id$="_options"]');
+        await this.page.evaluate(() => {
+            const form = document.querySelector('form[id$="_options"]');
+            const win = window as typeof window & { __wprSubmitInterceptor?: (event: Event) => void };
+
+            if (!form || win.__wprSubmitInterceptor) {
+                return;
+            }
+
+            win.__wprSubmitInterceptor = (event: Event) => {
+                event.preventDefault();
+            };
+
+            form.addEventListener('submit', win.__wprSubmitInterceptor, true);
+        });
+    }
+
+    /**
+     * Restores the default submit behavior for the WP Rocket settings form.
+     *
+     * @return {Promise<void>}
+     */
+    private resumeSettingsFormSubmit = async (): Promise<void> => {
+        await this.page.evaluate(() => {
+            const form = document.querySelector('form[id$="_options"]');
+            const win = window as typeof window & { __wprSubmitInterceptor?: (event: Event) => void };
+
+            if (!form || !win.__wprSubmitInterceptor) {
+                return;
+            }
+
+            form.removeEventListener('submit', win.__wprSubmitInterceptor, true);
+            delete win.__wprSubmitInterceptor;
+        });
     }
 
     /**


### PR DESCRIPTION
# Description

Fixes #295 
Updates the “Enable all features” smoke test to type “test” into every WP Rocket text field and fail immediately if any browser validation alert appears. This helps catch regressions where built-in validation prevents saving when all options are enabled.

## Type of change

- [ ] New feature (non-breaking change which adds functionality).
- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] Enhancement (non-breaking change which improves an existing functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as before).
- [ ] Sub-task of #(issue number)
- [ ] Chore
- [ ] Release

## Detailed scenario

### What was tested

Ran the “Enable all features” scenario with `npm run test:test`:
- First using 3.20.1.1 (where the issue exists) as new_release ⇒ test failed
<img width="1483" height="931" alt="Screenshot 2025-11-14 at 00 24 48" src="https://github.com/user-attachments/assets/912748fb-6776-4d69-b01d-d77a24cee378" />

- Then using 3.20.1.2 (where the issue is fixed) ⇒ test passed
<img width="1036" height="772" alt="Screenshot 2025-11-14 at 00 15 25" src="https://github.com/user-attachments/assets/244a5081-b185-490c-a26c-3f54aa8c7acc" />

Observe the step “I enable all settings with text inputs”:
- All settings are toggled on.
- Each text/textarea field is briefly filled with "test".
- The scenario fails if any native browser alert appears (e.g., “Please enter a valid URL”).

### How to test
Run command `npm run test:smoke`

## Technical description

### Documentation

- Added enableAllOptionsWithTextInputs() in utils/page-utils.ts. It calls the existing enable-all helper, then `validateTextInputsWithoutDialogs()` which:
   - Loops through each WP Rocket section nav item.
   - For every visible editable text/textarea field (limited to safe input types), fills “test”, presses Enter, waits briefly, and restores the previous value.
   - Captures/ dismisses any Playwright `dialog` event and reports which field triggered it.
   - Suppresses the settings form submit while Enter is pressed by attaching a temporary listener `(__wprSubmitInterceptor)` so we never save unintended data.
- Step `When I enable all settings with text inputs` now reuses that helper for cleaner scenarios.

### New dependencies

None.

### Risks

None.

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification

*If some mandatory items are not relevant, explain why in this section.*

# Additional Checks
- [x] In the case of complex code, I wrote comments to explain it.
- [ ] When possible, I prepared ways to observe the implemented system (logs, data, etc.).
- [x] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.)
