### PR TITLE
activate template loader plugin if it was disabled before running tests

### DIFF
--- a/src/support/hooks.ts
+++ b/src/support/hooks.ts
@@ -27,6 +27,15 @@ import type { Selectors } from "../../utils/types";
 import type { Section } from "../../utils/types";
 // import {configurations, getWPDir} from "../../utils/configurations";
 
+
+/**
+ * The name of the template loader plugin.
+ * This plugin must be active before running tests to avoid false positives.
+ * @constant {string}
+ */
+const TEMPLATE_LOADER_PLUGIN = 'template-loader-plugin-master';
+
+
 /**
  * The Playwright Chromium browser instance used for testing.
  */
@@ -57,10 +66,10 @@ BeforeAll(async function (this: ICustomWorld) {
         await deleteFolder('./backstop_data/bitmaps_test');
         
         // Check if template loader plugin is active, activate if not
-        const isTemplateLoaderActive = await isPluginActive('template-loader-plugin-master');
+        const isTemplateLoaderActive = await isPluginActive(TEMPLATE_LOADER_PLUGIN);
         if (!isTemplateLoaderActive) {
             console.log('Template loader plugin is not active, activating...');
-            await activatePlugin('template-loader-plugin-master');
+            await activatePlugin(TEMPLATE_LOADER_PLUGIN);
         } else {
             console.log('Template loader plugin is already active');
         }

--- a/src/support/hooks.ts
+++ b/src/support/hooks.ts
@@ -22,7 +22,7 @@ import { PageUtils } from "../../utils/page-utils";
 import { deleteFolder, isWprRelatedError } from "../../utils/helpers";
 import {WP_SSH_ROOT_DIR,} from "../../config/wp.config";
 import { After, AfterAll, Before, BeforeAll, Status, setDefaultTimeout } from "@cucumber/cucumber";
-import {rename, exists, rm, testSshConnection, installRemotePlugin, activatePlugin, uninstallPlugin, readFile} from "../../utils/commands";
+import {rename, exists, rm, testSshConnection, installRemotePlugin, activatePlugin, uninstallPlugin, readFile, isPluginActive} from "../../utils/commands";
 import type { Selectors } from "../../utils/types";
 import type { Section } from "../../utils/types";
 // import {configurations, getWPDir} from "../../utils/configurations";
@@ -55,7 +55,19 @@ BeforeAll(async function (this: ICustomWorld) {
         await rm(debugLogPath);
 
         await deleteFolder('./backstop_data/bitmaps_test');
+        
+        // Check if template loader plugin is active, activate if not
+        const isTemplateLoaderActive = await isPluginActive('template-loader-plugin-master');
+        if (!isTemplateLoaderActive) {
+            console.log('Template loader plugin is not active, activating...');
+            await activatePlugin('template-loader-plugin-master');
+        } else {
+            console.log('Template loader plugin is already active');
+        }
+        
         browser = await chromium.launch({ headless: false });
+
+        
     } catch (error) {
         console.error('Setup failed: ', error.message);
         throw new Error('Setup failed: ' + error.message);

--- a/src/support/results/expectedResultsDesktop.json
+++ b/src/support/results/expectedResultsDesktop.json
@@ -418,7 +418,7 @@
     "viewport": [
     "/wp-content/rocket-test-data/images/lcp/WF4.jpg.avif", "/wp-content/rocket-test-data/images/lcp/WF4.jpg.webp", 
     "/wp-content/rocket-test-data/images/lcp/WF4.jpg"],
-    "enabled": true
+    "enabled": false
   },
   "lcp_picture_responsive_type": {
     "comment": "Has a bug currently in UI#7547",
@@ -430,7 +430,7 @@
       "/wp-content/rocket-test-data/images/lcp/istockphoto-1148323720-612x612-1.jpg.webp 1024w, /wp-content/rocket-test-data/images/lcp/istockphoto-1148323720-612x612-1-450x380.jpg.webp 450w, /wp-content/rocket-test-data/images/lcp/istockphoto-1148323720-612x612-1-600x373.jpg.webp 600w",
       "https://new.rocketlabsqa.ovh/wp-content/rocket-test-data/images/lcp/istockphoto-1148323720-612x612-1.jpg"
   ],
-    "enabled": true
+    "enabled": false
   },
   "lcp_picture_template2_maxheight": {
     "lcp": [

--- a/utils/commands.ts
+++ b/utils/commands.ts
@@ -262,6 +262,18 @@ export async function isPluginInstalled(name: string): Promise<boolean> {
 }
 
 /**
+ * Check if plugin is active
+ * @function
+ * @name isPluginActive
+ * @async
+ * @param {string} name - The name of the plugin to be checked if active.
+ * @returns {Promise<boolean>} - A Promise that resolves to true if plugin is active, false otherwise.
+ */
+export async function isPluginActive(name: string): Promise<boolean> {
+    return await wp(`plugin is-active ${name}`, false);
+}
+
+/**
  * Delete a plugin if exist.
  * Note: this is not ideal for wpr or imagify plugins as it doesn't delete DB data which relies on uninstall hook.
  * @function


### PR DESCRIPTION
# Description

Fixes #289 
This PR enable template loader plugin if it was disabled before running tests to avoid false positive

## Type of change

- [ ] New feature (non-breaking change which adds functionality).
- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] Enhancement (non-breaking change which improves an existing functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as before).
- [ ] Sub-task of #(issue number)
- [ ] Chore
- [ ] Release

## Detailed scenario

### What was tested

- Running test using template while template loader is inactive => passed
- Running test using template while template loader is active => passed

### How to test

- Run all e2e => pass
<img width="1851" height="1009" alt="Screenshot from 2025-11-16 17-44-42" src="https://github.com/user-attachments/assets/238ed840-5724-41d5-9c60-09e1adfd6e7b" />

## Technical description

### Documentation
- it adds check in before all on template loader plugin status
- adds new function to check if plugin is active
- reuse activate plugin function
- we assume that template loader plugin is already installed

### New dependencies

N/A
### Risks

N/A
# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [ ] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [ ] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification

N/A
# Additional Checks
- [x] In the case of complex code, I wrote comments to explain it.
- [ ] When possible, I prepared ways to observe the implemented system (logs, data, etc.).
- [ ] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.)
