### PR TITLE
Enhancement/241 add smoke for preconnect external

### DIFF
--- a/src/features/prefetch-external-domain.feature
+++ b/src/features/prefetch-external-domain.feature
@@ -1,0 +1,13 @@
+@prefetchexternal @setup @priorityelements
+Feature: Beacon script captures the prefetch external domains
+
+    Background:
+        Given I am logged in
+        And plugin is installed 'new_release'
+        And plugin is activated
+@test
+    Scenario: Beacon captures expected external domains
+        Given I log out
+        And I visit the urls for prefetch External Domain
+        Then domains should be as expected 
+

--- a/src/features/prefetch-external-domain.feature
+++ b/src/features/prefetch-external-domain.feature
@@ -5,9 +5,9 @@ Feature: Beacon script captures the prefetch external domains
         Given I am logged in
         And plugin is installed 'new_release'
         And plugin is activated
-@test
-    Scenario: Beacon captures expected external domains
+
+    Scenario: Beacon captures expected external domains in DB
         Given I log out
-        And I visit the urls for prefetch External Domain
+        When I visit the urls for prefetch External Domain
         Then domains should be as expected
 

--- a/src/features/prefetch-external-domain.feature
+++ b/src/features/prefetch-external-domain.feature
@@ -9,5 +9,5 @@ Feature: Beacon script captures the prefetch external domains
     Scenario: Beacon captures expected external domains
         Given I log out
         And I visit the urls for prefetch External Domain
-        Then domains should be as expected 
+        Then domains should be as expected
 

--- a/src/support/hooks.ts
+++ b/src/support/hooks.ts
@@ -22,7 +22,7 @@ import { PageUtils } from "../../utils/page-utils";
 import { deleteFolder, isWprRelatedError } from "../../utils/helpers";
 import {WP_SSH_ROOT_DIR,} from "../../config/wp.config";
 import { After, AfterAll, Before, BeforeAll, Status, setDefaultTimeout } from "@cucumber/cucumber";
-import {rename, exists, rm, testSshConnection, installRemotePlugin, activatePlugin, uninstallPlugin, readFile, isPluginActive} from "../../utils/commands";
+import {rename, exists, rm, testSshConnection, installRemotePlugin, activatePlugin, uninstallPlugin, readFile, isPluginActive, isPluginInstalled} from "../../utils/commands";
 import type { Selectors } from "../../utils/types";
 import type { Section } from "../../utils/types";
 // import {configurations, getWPDir} from "../../utils/configurations";
@@ -65,13 +65,19 @@ BeforeAll(async function (this: ICustomWorld) {
 
         await deleteFolder('./backstop_data/bitmaps_test');
         
-        // Check if template loader plugin is active, activate if not
-        const isTemplateLoaderActive = await isPluginActive(TEMPLATE_LOADER_PLUGIN);
-        if (!isTemplateLoaderActive) {
-            console.log('Template loader plugin is not active, activating...');
-            await activatePlugin(TEMPLATE_LOADER_PLUGIN);
+        // Check if template loader plugin is installed
+        const isTemplateLoaderInstalled = await isPluginInstalled(TEMPLATE_LOADER_PLUGIN);
+        if (isTemplateLoaderInstalled) {
+            // Check if template loader plugin is active, activate if not
+            const isTemplateLoaderActive = await isPluginActive(TEMPLATE_LOADER_PLUGIN);
+            if (!isTemplateLoaderActive) {
+                console.log('Template loader plugin is not active, activating...');
+                await activatePlugin(TEMPLATE_LOADER_PLUGIN);
+            } else {
+                console.log('Template loader plugin is already active');
+            }
         } else {
-            console.log('Template loader plugin is already active');
+            console.log('Template loader plugin is not installed, skipping activation check');
         }
         
         browser = await chromium.launch({ headless: false });

--- a/src/support/results/expectedResultsPrefetchExternalDomain.json
+++ b/src/support/results/expectedResultsPrefetchExternalDomain.json
@@ -1,0 +1,34 @@
+{
+"prefetch_external1": {
+    "domains": ["https://example.com", "https://www.youtube.com"],
+    "enabled": true
+  },
+
+"preconnect_beexclusion": {
+    "domains": [],
+    "enabled": true
+  },
+  
+"preconnect_ext_domains_preload_fonts_compa": {
+    "domains": ["https://fonts.googleapis.com", "https://fonts.bunny.net",
+     "https://www.youtube.com", "https://player.vimeo.com"],
+    "enabled": true
+  },
+
+"preconnect_external_differentelements": {
+    "domains": ["https://example.org"],
+    "enabled": true
+  },
+
+"preconnect_external_dynamiclink": {
+    "domains": ["https://cdn.jsdelivr.net", "https://example.org",
+    "https://unpkg.com"],
+    "enabled": true
+  },
+  
+"preconnect_test_dupli": {
+    "domains": ["https://fonts.googleapis.com", "https://fonts.bunny.net",
+    "https://www.youtube.com","https://player.vimeo.com"],
+    "enabled": true
+  }
+}

--- a/src/support/steps/general.ts
+++ b/src/support/steps/general.ts
@@ -16,7 +16,7 @@ import { ICustomWorld } from "../../common/custom-world";
 import { Given, When, Then } from '@cucumber/cucumber';
 import {WP_BASE_URL} from '../../../config/wp.config';
 import scenarioUrls from "./../../../config/scenarioUrls.json";
-import { compareReference, isTagPresent, getScenarioTag, batchUpdateVRTestUrl, setHelperFilter } from "../../../utils/helpers";
+import { compareReference, isTagPresent, getScenarioTag, batchUpdateVRTestUrl} from "../../../utils/helpers";
 import type { Section } from "../../../utils/types";
 import { Page } from '@playwright/test';
 import {
@@ -29,7 +29,6 @@ import backstop from 'backstopjs';
  */
 Given('I am logged in', async function (this: ICustomWorld) {
     await this.utils.auth();
- //   await setHelperFilter(this.page, 'rocket_rocket_insights_enabled', 'false');
 });
 
 /**

--- a/src/support/steps/general.ts
+++ b/src/support/steps/general.ts
@@ -16,7 +16,7 @@ import { ICustomWorld } from "../../common/custom-world";
 import { Given, When, Then } from '@cucumber/cucumber';
 import {WP_BASE_URL} from '../../../config/wp.config';
 import scenarioUrls from "./../../../config/scenarioUrls.json";
-import { compareReference, isTagPresent, getScenarioTag, batchUpdateVRTestUrl } from "../../../utils/helpers";
+import { compareReference, isTagPresent, getScenarioTag, batchUpdateVRTestUrl, setHelperFilter } from "../../../utils/helpers";
 import type { Section } from "../../../utils/types";
 import { Page } from '@playwright/test';
 import {
@@ -29,6 +29,7 @@ import backstop from 'backstopjs';
  */
 Given('I am logged in', async function (this: ICustomWorld) {
     await this.utils.auth();
+ //   await setHelperFilter(this.page, 'rocket_rocket_insights_enabled', 'false');
 });
 
 /**

--- a/src/support/steps/lcp-beacon-script.ts
+++ b/src/support/steps/lcp-beacon-script.ts
@@ -21,7 +21,7 @@ import fs from 'fs/promises';
 let data: string,
     truthy: boolean = true,
     failMsg: string,
-    jsonData: Record<string, { lcp: string[]; viewport: string[]; fonts: string[];enabled: boolean, comment: string; }>,
+    jsonData: Record<string, { lcp: string[]; viewport: string[]; fonts: string[]; domains: string[]; enabled: boolean, comment: string; }>,
     isDbResultAvailable: boolean = true,
     lcpLLImages: LLImagesData = {},
     singlePageLcp : SinglePageLCPImages = {url: '', lcp: '', viewport: ''};
@@ -31,6 +31,7 @@ type ActualData = {
   lcp?: string;
   viewport?: string;
   fonts?: string;
+  domains?: string;
   comment?: string;
 };
 const actual: Record<string, ActualData> = {};
@@ -280,6 +281,32 @@ When('I visit the urls for preload fonts', async function (this: ICustomWorld) {
 
 
 /**
+ * Executes step to visit page and get prefetch external domain data from DB.
+ */
+When('I visit the urls for prefetch External Domain', async function (this: ICustomWorld) {
+    const viewPortWidth: number = 1600,
+        viewPortHeight: number = 700,
+        resultFile: string = './src/support/results/expectedResultsPrefetchExternalDomain.json',
+        isMobile = 0;
+
+    await visitUrlsAndFetchData(this, {
+        resultFile,
+        viewPortWidth,
+        viewPortHeight,
+        isMobile,
+        getSqlQuery: (tablePrefix, key, isMobile) => 
+            `SELECT domains FROM ${tablePrefix}wpr_preconnect_external_domains WHERE url LIKE "%${key}%" AND is_mobile = ${isMobile}`,
+        populateActualData: (key, url, resultFromStdout) => ({
+            url: url,
+            domains: resultFromStdout[0].domains,
+            comment: jsonData[key].comment ?? ''
+        }),
+        contextName: 'prefetch external domain'
+    });
+});
+
+
+/**
  * Executes the step to assert that LCP & ATF should be as expected.
  */
 Then('lcp and atf should be as expected for {string}', async function (this: ICustomWorld, formFactor: string) {
@@ -363,6 +390,53 @@ Then('preload fonts should be as expected', async function (this: ICustomWorld) 
                 truthy = false;
                 for (const m of missing) {
                     failMsg += `Expected preload font - ${m} for ${actual[key].url} is not present in actual - ${actualFonts}\nmore info -- ( ${actual[key].comment} )\n\n\n`;
+                }
+            }
+        }
+    }
+// Log fail message from Expectation mismatch before failing test.
+    if (failMsg !== '') {
+        throw new Error(failMsg);
+    }
+// Fail test when there is expectation mismatch.
+    expect(truthy).toBeTruthy();
+});
+
+/**
+ * Executes the step to assert that prefetch domains should be as expected.
+ */
+Then('domains should be as expected', async function (this: ICustomWorld) {
+    // Log fail messages from DB query before failing test.
+    if (failMsg !== '') {
+        console.log('\x1b[31m%s\x1b[0m',failMsg);
+         // Fail test when no DB result is found.
+        expect(isDbResultAvailable).toBeTruthy();
+        return;
+    }
+
+    truthy = true;
+
+    // Iterate over the data
+    for (const key in jsonData) {
+        if (Object.hasOwnProperty.call(jsonData, key) && jsonData[key].enabled === true) {
+            const expected = jsonData[key];
+            const expectedDomains: string[] = expected.domains || [];
+            let actualDomains: string[] = [];
+            try {
+                actualDomains = JSON.parse(actual[key].domains || '[]');
+            } catch (e) {
+                actualDomains = (actual[key].domains || '')
+                    .split(',')
+                    .map(d => d.trim())
+                    .filter(Boolean);
+            }
+
+            const missing = findUnmatchedExpectations(expectedDomains, actualDomains);
+
+            if (missing.length) {
+                truthy = false;
+                for (const m of missing) {
+                    failMsg += `Expected prefetch domain - ${m} for ${actual[key].url} is not present in actual - ${actualDomains}\nmore info -- ( ${actual[key].comment} )\n\n\n`;
                 }
             }
         }

--- a/src/support/steps/lcp-beacon-script.ts
+++ b/src/support/steps/lcp-beacon-script.ts
@@ -18,6 +18,10 @@ import {checkLcpOrViewport, extractFromStdout} from "../../../utils/helpers";
 import {WP_BASE_URL} from "../../../config/wp.config";
 import fs from 'fs/promises';
 
+// Viewport dimension constants
+const VIEWPORT_DESKTOP = { width: 1600, height: 700 };
+const VIEWPORT_MOBILE = { width: 389, height: 829 };
+
 let data: string,
     truthy: boolean = true,
     failMsg: string,
@@ -60,6 +64,67 @@ const findUnmatchedExpectations = (expectedList: string[], actualList: string[])
   }
   return unmatched;
 };
+
+/**
+ * Parse array field from database result.
+ * Handles both JSON format and comma-separated strings.
+ */
+const parseArrayField = (fieldValue: string | undefined): string[] => {
+  if (!fieldValue) return [];
+  
+  try {
+    return JSON.parse(fieldValue);
+  } catch (e) {
+    return fieldValue
+      .split(',')
+      .map(item => item.trim())
+      .filter(Boolean);
+  }
+};
+
+/**
+ * Validate array field expectations with common error handling.
+ * Reusable for fonts, domains, and other array-based validations.
+ */
+async function validateArrayFieldExpectations(
+  fieldName: 'fonts' | 'domains',
+  fieldLabel: string
+): Promise<void> {
+  // Log fail messages from DB query before failing test.
+  if (failMsg !== '') {
+    console.log('\x1b[31m%s\x1b[0m', failMsg);
+    // Fail test when no DB result is found.
+    expect(isDbResultAvailable).toBeTruthy();
+    return;
+  }
+
+  truthy = true;
+
+  // Iterate over the data
+  for (const key in jsonData) {
+    if (Object.hasOwnProperty.call(jsonData, key) && jsonData[key].enabled === true) {
+      const expected = jsonData[key];
+      const expectedArray: string[] = expected[fieldName] || [];
+      const actualArray: string[] = parseArrayField(actual[key][fieldName]);
+
+      const missing = findUnmatchedExpectations(expectedArray, actualArray);
+
+      if (missing.length) {
+        truthy = false;
+        for (const m of missing) {
+          failMsg += `Expected ${fieldLabel} - ${m} for ${actual[key].url} is not present in actual - ${actualArray}\nmore info -- ( ${actual[key].comment} )\n\n\n`;
+        }
+      }
+    }
+  }
+  
+  // Log fail message from Expectation mismatch before failing test.
+  if (failMsg !== '') {
+    throw new Error(failMsg);
+  }
+  // Fail test when there is expectation mismatch.
+  expect(truthy).toBeTruthy();
+}
 // --- end helpers ---
 
 /**
@@ -134,10 +199,7 @@ async function visitUrlsAndFetchData(
 When('I visit the urls and check for lazyload', async function (this: ICustomWorld) {
     const resultFile: string = './src/support/results/expectedResultsDesktop.json';
 
-    await this.page.setViewportSize({
-        width: 1600,
-        height: 700
-    });
+    await this.page.setViewportSize(VIEWPORT_DESKTOP);
 
     data = await fs.readFile(resultFile, 'utf8');
     jsonData = JSON.parse(data);
@@ -188,22 +250,12 @@ When('I visit the urls and check for lazyload', async function (this: ICustomWor
 
 
 // visit URL
-When(
-    'I visit the url {string} for {string}',
+When('I visit the url {string} for {string}',
     async function (this: ICustomWorld, templateKey: string, formFactor: string) {
-        let viewPortWidth: number = 1600,
-            viewPortHeight: number = 700;
+        // Set device viewport based on formFactor
+        const viewport = formFactor === 'mobile' ? VIEWPORT_MOBILE : VIEWPORT_DESKTOP;
 
-        // Set device viewport and result file based on formFactor
-        if (formFactor === 'mobile') {
-            viewPortWidth = 389;
-            viewPortHeight = 829;
-        }
-
-        await this.page.setViewportSize({
-            width: viewPortWidth,
-            height: viewPortHeight
-        });
+        await this.page.setViewportSize(viewport);
 
         // Visit the page url
         await this.utils.visitPage(templateKey);
@@ -220,15 +272,13 @@ When(
  * Executes step to visit page based on the form factor(desktop/mobile) and get the LCP/ATF data from DB.
  */
 When('I visit the urls for {string}', async function (this: ICustomWorld, formFactor: string) {
-    let viewPortWidth: number = 1600,
-        viewPortHeight: number = 700,
-        resultFile: string = './src/support/results/expectedResultsDesktop.json',
+    let resultFile: string = './src/support/results/expectedResultsDesktop.json',
         isMobile = 0;
 
-    // Set page to be visited in mobile.
+    // Set viewport and result file based on formFactor
+    const viewport = formFactor === 'mobile' ? VIEWPORT_MOBILE : VIEWPORT_DESKTOP;
+    
     if (formFactor === 'mobile') {
-        viewPortWidth = 389;
-        viewPortHeight = 829;
         resultFile = './src/support/results/expectedResultsMobile.json';
     }
 
@@ -238,8 +288,8 @@ When('I visit the urls for {string}', async function (this: ICustomWorld, formFa
 
     await visitUrlsAndFetchData(this, {
         resultFile,
-        viewPortWidth,
-        viewPortHeight,
+        viewPortWidth: viewport.width,
+        viewPortHeight: viewport.height,
         isMobile,
         getSqlQuery: (tablePrefix, key, isMobile) => 
             `SELECT lcp, viewport FROM ${tablePrefix}wpr_above_the_fold WHERE url LIKE "%${key}%" AND is_mobile = ${isMobile}`,
@@ -258,15 +308,13 @@ When('I visit the urls for {string}', async function (this: ICustomWorld, formFa
  * Executes step to visit page and get preload fonts data from DB.
  */
 When('I visit the urls for preload fonts', async function (this: ICustomWorld) {
-    const viewPortWidth: number = 1600,
-        viewPortHeight: number = 700,
-        resultFile: string = './src/support/results/expectedResultsPreloadFonts.json',
+    const resultFile: string = './src/support/results/expectedResultsPreloadFonts.json',
         isMobile = 0;
 
     await visitUrlsAndFetchData(this, {
         resultFile,
-        viewPortWidth,
-        viewPortHeight,
+        viewPortWidth: VIEWPORT_DESKTOP.width,
+        viewPortHeight: VIEWPORT_DESKTOP.height,
         isMobile,
         getSqlQuery: (tablePrefix, key, isMobile) => 
             `SELECT fonts FROM ${tablePrefix}wpr_preload_fonts WHERE url LIKE "%${key}%" AND is_mobile = ${isMobile}`,
@@ -284,15 +332,13 @@ When('I visit the urls for preload fonts', async function (this: ICustomWorld) {
  * Executes step to visit page and get prefetch external domain data from DB.
  */
 When('I visit the urls for prefetch External Domain', async function (this: ICustomWorld) {
-    const viewPortWidth: number = 1600,
-        viewPortHeight: number = 700,
-        resultFile: string = './src/support/results/expectedResultsPrefetchExternalDomain.json',
+    const resultFile: string = './src/support/results/expectedResultsPrefetchExternalDomain.json',
         isMobile = 0;
 
     await visitUrlsAndFetchData(this, {
         resultFile,
-        viewPortWidth,
-        viewPortHeight,
+        viewPortWidth: VIEWPORT_DESKTOP.width,
+        viewPortHeight: VIEWPORT_DESKTOP.height,
         isMobile,
         getSqlQuery: (tablePrefix, key, isMobile) => 
             `SELECT domains FROM ${tablePrefix}wpr_preconnect_external_domains WHERE url LIKE "%${key}%" AND is_mobile = ${isMobile}`,
@@ -359,94 +405,14 @@ Then('lcp and atf should be as expected for {string}', async function (this: ICu
  * Executes the step to assert that preload fonts should be as expected.
  */
 Then('preload fonts should be as expected', async function (this: ICustomWorld) {
-    // Log fail messages from DB query before failing test.
-    if (failMsg !== '') {
-        console.log('\x1b[31m%s\x1b[0m',failMsg);
-         // Fail test when no DB result is found.
-        expect(isDbResultAvailable).toBeTruthy();
-        return;
-    }
-
-    truthy = true;
-
-    // Iterate over the data
-    for (const key in jsonData) {
-        if (Object.hasOwnProperty.call(jsonData, key) && jsonData[key].enabled === true) {
-            const expected = jsonData[key];
-            const expectedFonts: string[] = expected.fonts || [];
-            let actualFonts: string[] = [];
-            try {
-                actualFonts = JSON.parse(actual[key].fonts || '[]');
-            } catch (e) {
-                actualFonts = (actual[key].fonts || '')
-                    .split(',')
-                    .map(f => f.trim())
-                    .filter(Boolean);
-            }
-
-            const missing = findUnmatchedExpectations(expectedFonts, actualFonts);
-
-            if (missing.length) {
-                truthy = false;
-                for (const m of missing) {
-                    failMsg += `Expected preload font - ${m} for ${actual[key].url} is not present in actual - ${actualFonts}\nmore info -- ( ${actual[key].comment} )\n\n\n`;
-                }
-            }
-        }
-    }
-// Log fail message from Expectation mismatch before failing test.
-    if (failMsg !== '') {
-        throw new Error(failMsg);
-    }
-// Fail test when there is expectation mismatch.
-    expect(truthy).toBeTruthy();
+    await validateArrayFieldExpectations('fonts', 'preload font');
 });
 
 /**
  * Executes the step to assert that prefetch domains should be as expected.
  */
 Then('domains should be as expected', async function (this: ICustomWorld) {
-    // Log fail messages from DB query before failing test.
-    if (failMsg !== '') {
-        console.log('\x1b[31m%s\x1b[0m',failMsg);
-         // Fail test when no DB result is found.
-        expect(isDbResultAvailable).toBeTruthy();
-        return;
-    }
-
-    truthy = true;
-
-    // Iterate over the data
-    for (const key in jsonData) {
-        if (Object.hasOwnProperty.call(jsonData, key) && jsonData[key].enabled === true) {
-            const expected = jsonData[key];
-            const expectedDomains: string[] = expected.domains || [];
-            let actualDomains: string[] = [];
-            try {
-                actualDomains = JSON.parse(actual[key].domains || '[]');
-            } catch (e) {
-                actualDomains = (actual[key].domains || '')
-                    .split(',')
-                    .map(d => d.trim())
-                    .filter(Boolean);
-            }
-
-            const missing = findUnmatchedExpectations(expectedDomains, actualDomains);
-
-            if (missing.length) {
-                truthy = false;
-                for (const m of missing) {
-                    failMsg += `Expected preconnect domain - ${m} for ${actual[key].url} is not present in actual - ${actualDomains}\nmore info -- ( ${actual[key].comment} )\n\n\n`;
-                }
-            }
-        }
-    }
-// Log fail message from Expectation mismatch before failing test.
-    if (failMsg !== '') {
-        throw new Error(failMsg);
-    }
-// Fail test when there is expectation mismatch.
-    expect(truthy).toBeTruthy();
+    await validateArrayFieldExpectations('domains', 'preconnect domain');
 });
 
 let lcpImages: Array<{ src: string; fetchpriority: string | boolean; lazyloaded: string | boolean }> = [];
@@ -508,10 +474,7 @@ When('I visit the {string} and check lcp-atf are not lazyloaded', async function
     // Reset truthy to true here.
     truthy = true;
 
-    await this.page.setViewportSize({
-        width: 1600,
-        height: 700
-    });
+    await this.page.setViewportSize(VIEWPORT_DESKTOP);
 
     await this.utils.visitPage(url);
 
@@ -551,10 +514,7 @@ When('I visit page {string} and check for lcp', async function (this:ICustomWorl
 
     const tablePrefix: string = await getWPTablePrefix();
 
-    await this.page.setViewportSize({
-        width: 1600,
-        height: 700,
-    });
+    await this.page.setViewportSize(VIEWPORT_DESKTOP);
 
     await this.utils.visitPage(page);
 

--- a/src/support/steps/lcp-beacon-script.ts
+++ b/src/support/steps/lcp-beacon-script.ts
@@ -280,9 +280,6 @@ When('I visit the urls for {string}', async function (this: ICustomWorld, formFa
     
     if (formFactor === 'mobile') {
         resultFile = './src/support/results/expectedResultsMobile.json';
-    }
-
-    if (formFactor !== 'desktop') {
         isMobile = 1;
     }
 

--- a/src/support/steps/lcp-beacon-script.ts
+++ b/src/support/steps/lcp-beacon-script.ts
@@ -436,7 +436,7 @@ Then('domains should be as expected', async function (this: ICustomWorld) {
             if (missing.length) {
                 truthy = false;
                 for (const m of missing) {
-                    failMsg += `Expected prefetch domain - ${m} for ${actual[key].url} is not present in actual - ${actualDomains}\nmore info -- ( ${actual[key].comment} )\n\n\n`;
+                    failMsg += `Expected preconnect domain - ${m} for ${actual[key].url} is not present in actual - ${actualDomains}\nmore info -- ( ${actual[key].comment} )\n\n\n`;
                 }
             }
         }


### PR DESCRIPTION
# Description

Fixes #241 
Add basic smoke test for preconnect external domain

## Type of change

- [x] New feature (non-breaking change which adds functionality).
- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] Enhancement (non-breaking change which improves an existing functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as before).
- [ ] Sub-task of #(issue number)
- [ ] Chore
- [ ] Release

## Detailed scenario

### What was tested

- e2e tests pass
<img width="1920" height="1080" alt="Screenshot from 2025-11-20 14-07-51" src="https://github.com/user-attachments/assets/787bc30c-7856-449b-b72e-79d103401ac9" />


### How to test

- same as above

## Technical description

### Documentation
The prefetch external domain feature follows the same pattern as:
1. **LCP/ATF Testing** - `wpr_above_the_fold` table
2. **Preload Fonts Testing** - `wpr_preload_fonts` table
- Note: possible refactor to minimize duplication could be done in a separate PR

### Shared Components
- `visitUrlsAndFetchData()` - Common visit/query logic
- `findUnmatchedExpectations()` - Regex-aware matching
- Beacon completion waiting
- Database query extraction

All three features share infrastructure for consistency and maintainability.
### New dependencies

N/A
### Risks

N/A
# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [ ] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [ ] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [ ] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification

N/A
# Additional Checks
- [x] In the case of complex code, I wrote comments to explain it.
- [ ] When possible, I prepared ways to observe the implemented system (logs, data, etc.).
- [x] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.)
