### PR TITLE
Fix/305 email verification popup while login

### DIFF
--- a/src/features/delay-js.feature
+++ b/src/features/delay-js.feature
@@ -21,7 +21,7 @@ Feature: No Regression with delayjs script udpate
         And expand mobile menu 
         And I click on link
         Then page navigated to the new page 'about-us'
-        When I log in
+        When I am logged in
         And I go to 'wp-admin/plugins.php'
         And activate 'wpml-multilingual-cms' plugin
         And I go to 'wp-admin/admin.php?page=sitepress-multilingual-cms/menu/languages.php'

--- a/src/features/enable-all-features.feature
+++ b/src/features/enable-all-features.feature
@@ -11,5 +11,5 @@ Feature: C1205 - Enabling all WP Rocket features should not throw any fatal erro
         And I enable all settings
         And I log out
         Then page loads successfully
-        When I log in
+        When I am logged in
         Then I must not see any error in debug.log

--- a/src/features/settings-export-import.feature
+++ b/src/features/settings-export-import.feature
@@ -36,7 +36,7 @@ Feature: C2148 - Should not change the content of existing fields
         When I log out
         And I visit site url
         And I go to 'hello-world'
-        And I log in
+        And I am logged in
         Then I must not see any error in debug.log
 
     Scenario: Should not change enabled fields with update

--- a/src/support/steps/general.ts
+++ b/src/support/steps/general.ts
@@ -176,12 +176,6 @@ Given('I install plugin {string}', async function (pluginUrl) {
     await installRemotePlugin(pluginUrl)
 });
 
-/**
- * Executes the step to log in.
- */
-When('I log in', async function (this: ICustomWorld) {
-    await this.utils.auth();
-});
 
 /**
  * Executes the step to visit a specific page.

--- a/utils/page-utils.ts
+++ b/utils/page-utils.ts
@@ -93,6 +93,12 @@ export class PageUtils {
         // Click login.
         await this.page.click('#wp-submit');
 
+        // Check if admin email confirmation form is displayed
+        if (await this.page.locator('#confirm_admin_email_nonce').isVisible()) {
+            await this.page.locator('#correct-admin-email').click();
+        }
+
+
         // Confirm login worked
         await this.page.waitForURL('**/wp-admin/**', { timeout: 5000 });
 
@@ -368,6 +374,7 @@ export class PageUtils {
         }
 
         await this.wpAdminLogin(user);
+
     }
 
     /**

--- a/utils/page-utils.ts
+++ b/utils/page-utils.ts
@@ -94,10 +94,9 @@ export class PageUtils {
         await this.page.click('#wp-submit');
 
         // Check if admin email confirmation form is displayed
-        if (await this.page.locator('#confirm_admin_email_nonce').isVisible()) {
+        if (await this.page.getByText('Administration email verification').isVisible()) {
             await this.page.locator('#correct-admin-email').click();
         }
-
 
         // Confirm login worked
         await this.page.waitForURL('**/wp-admin/**', { timeout: 5000 });


### PR DESCRIPTION
# Description

Fixes #305 
It should confirm email verification when logging if displayed
## Type of change

- [ ] New feature (non-breaking change which adds functionality).
- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] Enhancement (non-breaking change which improves an existing functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as before).
- [ ] Sub-task of #(issue number)
- [ ] Chore
- [ ] Release

## Detailed scenario

### What was tested

- Run all e2e => pass
<img width="1920" height="1080" alt="Screenshot from 2025-11-23 12-10-46" src="https://github.com/user-attachments/assets/65ac7050-c4fe-4ea6-82e0-21a83dd59f0b" />


### How to test

- As above

## Technical description

### Documentation

- Added check after adding user email /pw if the email verification displayed then click email is correct
- Removed duplicated login function and reused existing one

### New dependencies

N/A

### Risks

N/A

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [ ] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [ ] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification

N/A

# Additional Checks
- [x] In the case of complex code, I wrote comments to explain it.
- [ ] When possible, I prepared ways to observe the implemented system (logs, data, etc.).
- [ ] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.)
