### PR TITLE
Enhancement #6: As a QA engineer, I want the plugin versions to be automatically handled so that I can easily run tests on a selected version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /config/wp.config.ts
+/config/plugin.config.ts
 /node_modules
 /artifacts
 /plugin/*.zip
@@ -14,3 +15,7 @@
 .idea
 backstop.json
 /temp
+/.tmp-plugin-build
+
+#Ignore insiders AI rules
+.github/instructions/codacy.instructions.md

--- a/README.md
+++ b/README.md
@@ -72,10 +72,10 @@ E2E tests here are written with Playwright. Without further ado, let's meet belo
  ```
  
  **Supported version formats:**
- - Version number: `3.16.0` (downloads from GitHub release tags - requires GITHUB_TOKEN)
- - GitHub branch: `branch:develop` or `branch:release/3.16.0` (clones and builds from source)
- - GitHub tag: `tag:3.16.0` (clones and builds from tag)
- - Direct URL: `https://example.com/wp-rocket.zip`
+ - Version number: `3.16.0` (downloads source from GitHub release tags, then builds with npm/composer - requires GITHUB_TOKEN)
+ - GitHub branch: `branch:develop` or `branch:release/3.16.0` (clones and builds from source - requires GITHUB_TOKEN)
+ - GitHub tag: `tag:3.16.0` (clones and builds from tag - requires GITHUB_TOKEN)
+ - Direct URL: `https://example.com/wp-rocket.zip` (downloads pre-built zip)
  
  **Available override options:**
  - `--previous-stable` - Override the previous stable release version

--- a/README.md
+++ b/README.md
@@ -34,6 +34,71 @@ E2E tests here are written with Playwright. Without further ado, let's meet belo
  
  Copy `config/plugin.config.sample.ts` to `config/plugin.config.ts` and configure which WP Rocket versions to use for testing. See the sample file for detailed examples and configuration options.
  
+ #### CLI Version Overrides
+ 
+ You can override plugin versions directly from the command line without modifying the config file! This is useful for quick testing with different versions:
+ 
+ **Override single version:**
+ ```bash
+ # Test with a specific previous_stable version
+ npm run test:e2e -- --previous-stable=3.16.0
+ 
+ # Test with a development branch
+ npm run test:e2e -- --new-release=branch:develop
+ 
+ # Test with a specific tag
+ npm run test:e2e -- --new-release=tag:3.16.1
+ ```
+ 
+ **Override multiple versions:**
+ ```bash
+ # Override both previous_stable and new_release
+ npm run test:e2e -- --previous-stable=3.16.0 --new-release=3.16.1
+ 
+ # Mix version numbers with branches
+ npm run test:smoke -- --previous-stable=3.16.0 --new-release=branch:develop
+ ```
+ 
+ **Using environment variables:**
+ ```bash
+ # Set versions via environment variables
+ PREVIOUS_STABLE=3.16.0 NEW_RELEASE=3.16.1 npm run test:e2e
+ 
+ # Or export them for multiple test runs
+ export PREVIOUS_STABLE=3.16.0
+ export NEW_RELEASE=branch:develop
+ npm run test:e2e
+ npm run test:smoke
+ ```
+ 
+ **Supported version formats:**
+ - Version number: `3.16.0` (downloads from WP Rocket releases)
+ - GitHub branch: `branch:develop` or `branch:release/3.16.0`
+ - GitHub tag: `tag:3.16.0`
+ - Direct URL: `https://example.com/wp-rocket.zip`
+ 
+ **Available override options:**
+ - `--previous-stable` - Override the previous stable release version
+ - `--new-release` - Override the new release version being tested
+ - `--specific-version` - Override the specific version for rollback tests
+ 
+ **Examples for common scenarios:**
+ ```bash
+ # Test upgrade from 3.16.0 to latest develop branch
+ npm run test:e2e -- --previous-stable=3.16.0 --new-release=branch:develop
+ 
+ # Quick smoke test with specific versions
+ npm run test:smoke -- --new-release=3.16.2
+ 
+ # Visual regression with beta version
+ npm run test:vr -- --new-release=tag:3.16.2-beta5 --wproption=lazyloadCssBgImg
+ 
+ # Test with locally downloaded zip file
+ npm run test:e2e -- --new-release=https://your-server.com/custom-build.zip
+ ```
+ 
+ The CLI overrides will automatically trigger a download/build of the specified versions if they're not already in your `plugin/` directory.
+ 
  ## Running Tests
  - Don't forget to install the [helper plugin](https://github.com/wp-media/wp-rocket-e2e-test-helper)
  - To run tests on playwright, simply run `npx playwright test` or `npm run test:e2e` which ever you prefer.

--- a/README.md
+++ b/README.md
@@ -4,13 +4,17 @@ E2E tests here are written with Playwright. Without further ado, let's meet belo
 ## Requirements
 - Do you still not have node installed? You'll be needing it.
 - Some tests don't come easy with just Playwright, so you need to install the [helper plugin](https://github.com/wp-media/wp-rocket-e2e-test-helper) on your test site. just download the zip from the repo.
-- You also need zip files of WP Rocket, I'll explain:
-  - zip for new release - **rename the zip file name to `new_release.zip`. e.g `wp-rocket_3.13.1.zip` becomes `new_release.zip`**
-  - zip for previous stable release - **rename the zip file name to `previous_stable`. e.g `wp-rocket_3.13.0.2.zip becomes `previous_stable.zip`**
-  - zip for 3.10.9 - **leave this as `wp-rocket_3.10.9.zip`**
-  - Make sure to put these files in the `./plugin` folder in the root - Playwright will pick these files when needed and use them during tests.
+- **WP Rocket plugin versions are now automatically managed!** 🎉
+  - Configure which versions to use in `config/plugin.config.ts`
+  - The test suite will automatically download/build the required versions
+  - Manual setup is no longer required unless you want to customize versions
   
-  **NB:** Files like the new release and previous stable release are not constant so make sure to always update as your tests fit.
+  **Optional manual management:**
+  - `npm run plugin:setup` - Download/build all configured versions
+  - `npm run plugin:list` - List all plugin files and their status
+  - `npm run plugin:clean` - Remove all plugin files
+  - `npm run plugin:validate` - Check if all required files exist
+  - `npm run plugin:setup -- --force` - Force rebuild even if files exist
   
  ## Installation
  - Clone this repo
@@ -25,6 +29,10 @@ E2E tests here are written with Playwright. Without further ado, let's meet belo
  Change the `live_username` & `live_password` & `WP_BASE_URL` to that of your test site.
  
  You can find this [here](https://github.com/wp-media/wp-rocket-e2e/blob/trunk/config/wp.config.sample.ts)
+ 
+ ### Plugin Version Configuration
+ 
+ Copy `config/plugin.config.sample.ts` to `config/plugin.config.ts` and configure which WP Rocket versions to use for testing. See the sample file for detailed examples and configuration options.
  
  ## Running Tests
  - Don't forget to install the [helper plugin](https://github.com/wp-media/wp-rocket-e2e-test-helper)

--- a/README.md
+++ b/README.md
@@ -72,15 +72,14 @@ E2E tests here are written with Playwright. Without further ado, let's meet belo
  ```
  
  **Supported version formats:**
- - Version number: `3.16.0` (downloads from WP Rocket releases)
- - GitHub branch: `branch:develop` or `branch:release/3.16.0`
- - GitHub tag: `tag:3.16.0`
+ - Version number: `3.16.0` (downloads from GitHub release tags - requires GITHUB_TOKEN)
+ - GitHub branch: `branch:develop` or `branch:release/3.16.0` (clones and builds from source)
+ - GitHub tag: `tag:3.16.0` (clones and builds from tag)
  - Direct URL: `https://example.com/wp-rocket.zip`
  
  **Available override options:**
  - `--previous-stable` - Override the previous stable release version
  - `--new-release` - Override the new release version being tested
- - `--specific-version` - Override the specific version for rollback tests
  
  **Examples for common scenarios:**
  ```bash

--- a/config/plugin.config.sample.ts
+++ b/config/plugin.config.sample.ts
@@ -33,18 +33,6 @@ export interface PluginVersionConfig {
     newRelease: string;
 
     /**
-     * Specific version for rollback/upgrade tests (currently 3.10.9).
-     * This version is used for specific test scenarios.
-     * 
-     * Can be:
-     * - A version number (e.g., '3.10.9') - will download from WP Rocket releases
-     * - A GitHub branch name prefixed with 'branch:' (e.g., 'branch:release/3.10.9')
-     * - A GitHub tag prefixed with 'tag:' (e.g., 'tag:3.10.9')
-     * - A URL pointing to a zip file
-     */
-    specificVersion?: string;
-
-    /**
      * GitHub repository information for building from branches.
      * Only required if using branch: or tag: prefixes.
      */
@@ -67,7 +55,6 @@ export interface PluginVersionConfig {
  * export const pluginConfig: PluginVersionConfig = {
  *     previousStable: '3.16.0',
  *     newRelease: '3.16.1',
- *     specificVersion: '3.10.9',
  * };
  * 
  * @example
@@ -75,7 +62,6 @@ export interface PluginVersionConfig {
  * export const pluginConfig: PluginVersionConfig = {
  *     previousStable: 'branch:release/3.16.0',
  *     newRelease: 'branch:develop',
- *     specificVersion: '3.10.9',
  *     repository: {
  *         owner: 'wp-media',
  *         name: 'wp-rocket',
@@ -88,7 +74,6 @@ export interface PluginVersionConfig {
  * export const pluginConfig: PluginVersionConfig = {
  *     previousStable: 'https://example.com/wp-rocket-3.16.0.zip',
  *     newRelease: 'https://example.com/wp-rocket-3.16.1.zip',
- *     specificVersion: '3.10.9',
  * };
  */
 export const pluginConfig: PluginVersionConfig = {
@@ -98,8 +83,6 @@ export const pluginConfig: PluginVersionConfig = {
     // NOTE: Pre-release (beta) versions like '3.20.2-beta5' may not be available at the standard release URL.
     // If you need to test a beta version, use a direct URL or a GitHub tag/branch instead (see examples above).
     newRelease: '3.20.2',      // Latest stable version to test
-    
-    specificVersion: '3.10.9',  // Specific version for rollback tests
     
     // Optional: Configure GitHub repository for branch-based builds
     repository: {

--- a/config/plugin.config.sample.ts
+++ b/config/plugin.config.sample.ts
@@ -13,10 +13,10 @@ export interface PluginVersionConfig {
      * This will be used for upgrade/downgrade tests.
      * 
      * Can be:
-     * - A version number (e.g., '3.16.0') - downloads source from GitHub releases/tags/v{version}
+     * - A version number (e.g., '3.16.0') - downloads source from GitHub releases/tags/v{version}, then builds it
      * - A GitHub branch name prefixed with 'branch:' (e.g., 'branch:release/3.16.0')
      * - A GitHub tag prefixed with 'tag:' (e.g., 'tag:3.16.0')
-     * - A URL pointing to a zip file
+     * - A URL pointing to a zip file (pre-built)
      */
     previousStable: string;
 
@@ -25,10 +25,10 @@ export interface PluginVersionConfig {
      * This is the main version being tested.
      * 
      * Can be:
-     * - A version number (e.g., '3.16.1') - downloads source from GitHub releases/tags/v{version}
+     * - A version number (e.g., '3.16.1') - downloads source from GitHub releases/tags/v{version}, then builds it
      * - A GitHub branch name prefixed with 'branch:' (e.g., 'branch:develop')
      * - A GitHub tag prefixed with 'tag:' (e.g., 'tag:3.16.1')
-     * - A URL pointing to a zip file
+     * - A URL pointing to a zip file (pre-built)
      */
     newRelease: string;
 

--- a/config/plugin.config.sample.ts
+++ b/config/plugin.config.sample.ts
@@ -13,7 +13,7 @@ export interface PluginVersionConfig {
      * This will be used for upgrade/downgrade tests.
      * 
      * Can be:
-     * - A version number (e.g., '3.16.0') - will download from WP Rocket releases
+     * - A version number (e.g., '3.16.0') - downloads source from GitHub releases/tags/v{version}
      * - A GitHub branch name prefixed with 'branch:' (e.g., 'branch:release/3.16.0')
      * - A GitHub tag prefixed with 'tag:' (e.g., 'tag:3.16.0')
      * - A URL pointing to a zip file
@@ -25,7 +25,7 @@ export interface PluginVersionConfig {
      * This is the main version being tested.
      * 
      * Can be:
-     * - A version number (e.g., '3.16.1') - will download from WP Rocket releases
+     * - A version number (e.g., '3.16.1') - downloads source from GitHub releases/tags/v{version}
      * - A GitHub branch name prefixed with 'branch:' (e.g., 'branch:develop')
      * - A GitHub tag prefixed with 'tag:' (e.g., 'tag:3.16.1')
      * - A URL pointing to a zip file
@@ -33,8 +33,9 @@ export interface PluginVersionConfig {
     newRelease: string;
 
     /**
-     * GitHub repository information for building from branches.
-     * Only required if using branch: or tag: prefixes.
+     * GitHub repository information.
+     * Required for downloading from GitHub (version numbers, branches, or tags).
+     * The token is needed to access private repository releases.
      */
     repository?: {
         owner: string;
@@ -51,10 +52,15 @@ export interface PluginVersionConfig {
  * Plugin version configuration.
  * 
  * @example
- * // Using version numbers (will download from releases)
+ * // Using version numbers (downloads from GitHub releases)
  * export const pluginConfig: PluginVersionConfig = {
  *     previousStable: '3.16.0',
  *     newRelease: '3.16.1',
+ *     repository: {
+ *         owner: 'wp-media',
+ *         name: 'wp-rocket',
+ *         token: process.env.GITHUB_TOKEN
+ *     }
  * };
  * 
  * @example

--- a/config/plugin.config.sample.ts
+++ b/config/plugin.config.sample.ts
@@ -94,7 +94,11 @@ export interface PluginVersionConfig {
 export const pluginConfig: PluginVersionConfig = {
     // Configure the versions you want to test here
     previousStable: '3.20.1',  // Previous stable version
-    newRelease: '3.20.2-beta5',      // Latest version to test
+    
+    // NOTE: Pre-release (beta) versions like '3.20.2-beta5' may not be available at the standard release URL.
+    // If you need to test a beta version, use a direct URL or a GitHub tag/branch instead (see examples above).
+    newRelease: '3.20.2',      // Latest stable version to test
+    
     specificVersion: '3.10.9',  // Specific version for rollback tests
     
     // Optional: Configure GitHub repository for branch-based builds
@@ -104,9 +108,3 @@ export const pluginConfig: PluginVersionConfig = {
         token: process.env.GITHUB_TOKEN,
     }
 };
-
-/**
- * Whether to force re-download/rebuild even if files exist.
- * Can be overridden via CLI flag: --force-plugin-rebuild
- */
-export const forceRebuild = process.env.npm_config_force_plugin_rebuild === 'true' || false;

--- a/config/plugin.config.sample.ts
+++ b/config/plugin.config.sample.ts
@@ -1,0 +1,112 @@
+/**
+ * @fileoverview
+ * Plugin version configuration sample for WP Rocket E2E tests.
+ * Copy this file to plugin.config.ts and update with your desired versions.
+ * 
+ * The plugin manager will automatically download or build the specified versions
+ * if they are not already present in the plugin/ directory.
+ */
+
+export interface PluginVersionConfig {
+    /**
+     * Previous stable release version.
+     * This will be used for upgrade/downgrade tests.
+     * 
+     * Can be:
+     * - A version number (e.g., '3.16.0') - will download from WP Rocket releases
+     * - A GitHub branch name prefixed with 'branch:' (e.g., 'branch:release/3.16.0')
+     * - A GitHub tag prefixed with 'tag:' (e.g., 'tag:3.16.0')
+     * - A URL pointing to a zip file
+     */
+    previousStable: string;
+
+    /**
+     * New release version.
+     * This is the main version being tested.
+     * 
+     * Can be:
+     * - A version number (e.g., '3.16.1') - will download from WP Rocket releases
+     * - A GitHub branch name prefixed with 'branch:' (e.g., 'branch:develop')
+     * - A GitHub tag prefixed with 'tag:' (e.g., 'tag:3.16.1')
+     * - A URL pointing to a zip file
+     */
+    newRelease: string;
+
+    /**
+     * Specific version for rollback/upgrade tests (currently 3.10.9).
+     * This version is used for specific test scenarios.
+     * 
+     * Can be:
+     * - A version number (e.g., '3.10.9') - will download from WP Rocket releases
+     * - A GitHub branch name prefixed with 'branch:' (e.g., 'branch:release/3.10.9')
+     * - A GitHub tag prefixed with 'tag:' (e.g., 'tag:3.10.9')
+     * - A URL pointing to a zip file
+     */
+    specificVersion?: string;
+
+    /**
+     * GitHub repository information for building from branches.
+     * Only required if using branch: or tag: prefixes.
+     */
+    repository?: {
+        owner: string;
+        name: string;
+        /**
+         * Personal Access Token for GitHub API (if needed for private repos or rate limits).
+         * Can also be set via GITHUB_TOKEN environment variable.
+         */
+        token?: string;
+    };
+}
+
+/**
+ * Plugin version configuration.
+ * 
+ * @example
+ * // Using version numbers (will download from releases)
+ * export const pluginConfig: PluginVersionConfig = {
+ *     previousStable: '3.16.0',
+ *     newRelease: '3.16.1',
+ *     specificVersion: '3.10.9',
+ * };
+ * 
+ * @example
+ * // Using GitHub branches
+ * export const pluginConfig: PluginVersionConfig = {
+ *     previousStable: 'branch:release/3.16.0',
+ *     newRelease: 'branch:develop',
+ *     specificVersion: '3.10.9',
+ *     repository: {
+ *         owner: 'wp-media',
+ *         name: 'wp-rocket',
+ *         token: process.env.GITHUB_TOKEN
+ *     }
+ * };
+ * 
+ * @example
+ * // Using direct URLs
+ * export const pluginConfig: PluginVersionConfig = {
+ *     previousStable: 'https://example.com/wp-rocket-3.16.0.zip',
+ *     newRelease: 'https://example.com/wp-rocket-3.16.1.zip',
+ *     specificVersion: '3.10.9',
+ * };
+ */
+export const pluginConfig: PluginVersionConfig = {
+    // Configure the versions you want to test here
+    previousStable: '3.20.1',  // Previous stable version
+    newRelease: '3.20.2-beta5',      // Latest version to test
+    specificVersion: '3.10.9',  // Specific version for rollback tests
+    
+    // Optional: Configure GitHub repository for branch-based builds
+    repository: {
+        owner: 'wp-media',
+        name: 'wp-rocket',
+        token: process.env.GITHUB_TOKEN,
+    }
+};
+
+/**
+ * Whether to force re-download/rebuild even if files exist.
+ * Can be overridden via CLI flag: --force-plugin-rebuild
+ */
+export const forceRebuild = process.env.npm_config_force_plugin_rebuild === 'true' || false;

--- a/package.json
+++ b/package.json
@@ -30,11 +30,16 @@
     "test:performancehints": "$npm_package_config_testCommand --tags @performancehints",
     "healthcheck": "ts-node healthcheck.ts",
     "push-report": "ts-node report.ts",
+    "open-report": "open ./test-results/cucumber-report.html",
     "wp-env": "wp-env",
     "test:bwpupstorage": "$npm_package_config_testCommand --tags @bwpupstorage",
     "test:bwpuponboarding": "$npm_package_config_testCommand --tags @bwpuponboarding",
     "test:bwpupsmoke": "$npm_package_config_testCommand --tags @bwpupsmoke",
-    "test:bwpup": "$npm_package_config_testCommand --tags @bwpup"
+    "test:bwpup": "$npm_package_config_testCommand --tags @bwpup",
+    "plugin:setup": "ts-node plugin-manager-cli.ts setup",
+    "plugin:list": "ts-node plugin-manager-cli.ts list",
+    "plugin:clean": "ts-node plugin-manager-cli.ts clean",
+    "plugin:validate": "ts-node plugin-manager-cli.ts validate"
   },
   "repository": {
     "type": "git",

--- a/plugin-manager-cli.ts
+++ b/plugin-manager-cli.ts
@@ -18,7 +18,7 @@ const args = process.argv.slice(2);
 const command = args[0] || 'setup';
 const force = args.includes('--force') || args.includes('-f');
 
-async function main() {
+async function main(): Promise<void> {
     try {
         switch (command) {
             case 'setup':
@@ -33,7 +33,7 @@ async function main() {
                 await cleanPluginFiles();
                 break;
             
-            case 'validate':
+            case 'validate': {
                 const isValid = await validatePluginFiles();
                 if (isValid) {
                     console.log('✅ All required plugin files are present\n');
@@ -44,6 +44,7 @@ async function main() {
                     process.exit(1);
                 }
                 break;
+            }
             
             case 'help':
             case '--help':
@@ -57,12 +58,13 @@ async function main() {
                 process.exit(1);
         }
     } catch (error) {
-        console.error('Error:', error.message);
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        console.error('Error:', errorMessage);
         process.exit(1);
     }
 }
 
-function printHelp() {
+function printHelp(): void {
     console.log(`
 WP Rocket Plugin Manager
 

--- a/plugin-manager-cli.ts
+++ b/plugin-manager-cli.ts
@@ -1,0 +1,93 @@
+#!/usr/bin/env node
+
+/**
+ * @fileoverview
+ * CLI tool for managing WP Rocket plugin versions for E2E tests.
+ * 
+ * Usage:
+ *   npm run plugin:setup              - Setup all configured plugin versions
+ *   npm run plugin:setup -- --force   - Force rebuild/re-download even if files exist
+ *   npm run plugin:list               - List all plugin files and their status
+ *   npm run plugin:clean              - Remove all plugin files
+ *   npm run plugin:validate           - Check if all required plugin files exist
+ */
+
+import { setupPluginVersions, listPluginFiles, cleanPluginFiles, validatePluginFiles } from './utils/plugin-manager';
+
+const args = process.argv.slice(2);
+const command = args[0] || 'setup';
+const force = args.includes('--force') || args.includes('-f');
+
+async function main() {
+    try {
+        switch (command) {
+            case 'setup':
+                await setupPluginVersions(force);
+                break;
+            
+            case 'list':
+                await listPluginFiles();
+                break;
+            
+            case 'clean':
+                await cleanPluginFiles();
+                break;
+            
+            case 'validate':
+                const isValid = await validatePluginFiles();
+                if (isValid) {
+                    console.log('✅ All required plugin files are present\n');
+                    process.exit(0);
+                } else {
+                    console.log('❌ Some required plugin files are missing\n');
+                    console.log('Run "npm run plugin:setup" to download/build them.\n');
+                    process.exit(1);
+                }
+                break;
+            
+            case 'help':
+            case '--help':
+            case '-h':
+                printHelp();
+                break;
+            
+            default:
+                console.error(`Unknown command: ${command}`);
+                printHelp();
+                process.exit(1);
+        }
+    } catch (error) {
+        console.error('Error:', error.message);
+        process.exit(1);
+    }
+}
+
+function printHelp() {
+    console.log(`
+WP Rocket Plugin Manager
+
+Usage: npm run plugin:<command> [options]
+
+Commands:
+  setup                Setup all configured plugin versions
+  list                 List all plugin files and their status
+  clean                Remove all plugin files
+  validate             Check if all required plugin files exist
+  help                 Show this help message
+
+Options:
+  --force, -f         Force rebuild/re-download even if files exist
+
+Examples:
+  npm run plugin:setup
+  npm run plugin:setup -- --force
+  npm run plugin:list
+  npm run plugin:clean
+  npm run plugin:validate
+
+Configuration:
+  Edit config/plugin.config.ts to configure which plugin versions to use.
+    `);
+}
+
+main();

--- a/src/support/hooks.ts
+++ b/src/support/hooks.ts
@@ -26,6 +26,7 @@ import {rename, exists, rm, testSshConnection, installRemotePlugin, activatePlug
 import type { Selectors } from "../../utils/types";
 import type { Section } from "../../utils/types";
 import { setupPluginVersions, validatePluginFiles } from "../../utils/plugin-manager";
+import { parseVersionOverrides } from "../../utils/version-override";
 // import {configurations, getWPDir} from "../../utils/configurations";
 
 
@@ -66,12 +67,15 @@ BeforeAll(async function (this: ICustomWorld) {
 
         await deleteFolder('./backstop_data/bitmaps_test');
         
+        // Parse any CLI version overrides
+        const versionOverrides = parseVersionOverrides();
+        
         // Setup plugin versions automatically
         console.log('Checking plugin versions...');
         const pluginsValid = await validatePluginFiles();
         if (!pluginsValid) {
             console.log('Some plugin files are missing, downloading/building them...');
-            await setupPluginVersions();
+            await setupPluginVersions(false, versionOverrides);
         } else {
             console.log('All required plugin files are present');
         }

--- a/src/support/hooks.ts
+++ b/src/support/hooks.ts
@@ -25,6 +25,7 @@ import { After, AfterAll, Before, BeforeAll, Status, setDefaultTimeout } from "@
 import {rename, exists, rm, testSshConnection, installRemotePlugin, activatePlugin, uninstallPlugin, readFile, isPluginActive} from "../../utils/commands";
 import type { Selectors } from "../../utils/types";
 import type { Section } from "../../utils/types";
+import { setupPluginVersions, validatePluginFiles } from "../../utils/plugin-manager";
 // import {configurations, getWPDir} from "../../utils/configurations";
 
 
@@ -64,6 +65,16 @@ BeforeAll(async function (this: ICustomWorld) {
         await rm(debugLogPath);
 
         await deleteFolder('./backstop_data/bitmaps_test');
+        
+        // Setup plugin versions automatically
+        console.log('Checking plugin versions...');
+        const pluginsValid = await validatePluginFiles();
+        if (!pluginsValid) {
+            console.log('Some plugin files are missing, downloading/building them...');
+            await setupPluginVersions();
+        } else {
+            console.log('All required plugin files are present');
+        }
         
         // Check if template loader plugin is active, activate if not
         const isTemplateLoaderActive = await isPluginActive(TEMPLATE_LOADER_PLUGIN);

--- a/src/support/hooks.ts
+++ b/src/support/hooks.ts
@@ -25,8 +25,8 @@ import { After, AfterAll, Before, BeforeAll, Status, setDefaultTimeout } from "@
 import {rename, exists, rm, testSshConnection, installRemotePlugin, activatePlugin, uninstallPlugin, readFile, isPluginActive} from "../../utils/commands";
 import type { Selectors } from "../../utils/types";
 import type { Section } from "../../utils/types";
-import { setupPluginVersions, validatePluginFiles } from "../../utils/plugin-manager";
-import { parseVersionOverrides } from "../../utils/version-override";
+import { setupPluginVersions, validatePluginFiles, cleanPluginFiles, hasPluginConfigFile } from "../../utils/plugin-manager";
+import { parseVersionOverrides, hasVersionOverrides } from "../../utils/version-override";
 // import {configurations, getWPDir} from "../../utils/configurations";
 
 
@@ -69,15 +69,36 @@ BeforeAll(async function (this: ICustomWorld) {
         
         // Parse any CLI version overrides
         const versionOverrides = parseVersionOverrides();
+        const hasCliOverrides = hasVersionOverrides(versionOverrides);
+        const hasConfig = hasPluginConfigFile();
         
-        // Setup plugin versions automatically
+        // Setup plugin versions based on priority:
+        // 1. CLI overrides - always clean and re-download
+        // 2. Config file - clean and re-download
+        // 3. No CLI or config - use existing plugins in folder
         console.log('Checking plugin versions...');
-        const pluginsValid = await validatePluginFiles();
-        if (!pluginsValid) {
-            console.log('Some plugin files are missing, downloading/building them...');
+        
+        if (hasCliOverrides) {
+            console.log('CLI version overrides detected. Using CLI-specified versions.');
+            console.log('Cleaning existing plugin files and re-downloading...');
+            await cleanPluginFiles();
             await setupPluginVersions(false, versionOverrides);
+        } else if (hasConfig) {
+            console.log('No CLI version overrides detected. Using versions from config file.');
+            console.log('Cleaning existing plugin files and re-downloading...');
+            await cleanPluginFiles();
+            await setupPluginVersions(false);
         } else {
-            console.log('All required plugin files are present');
+            console.log('No CLI overrides or config file detected. Using existing plugin files in folder.');
+            const pluginsValid = await validatePluginFiles();
+            if (!pluginsValid) {
+                console.error('⚠️  Some required plugin files are missing!');
+                console.error('Please either:');
+                console.error('  1. Create config/plugin.config.ts and run tests again, OR');
+                console.error('  2. Use CLI overrides: npm run test:e2e -- --new-release=X.X.X --previous-stable=X.X.X');
+                throw new Error('Missing required plugin files and no configuration provided');
+            }
+            console.log('✓ All required plugin files are present');
         }
         
         // Check if template loader plugin is active, activate if not

--- a/utils/plugin-manager.ts
+++ b/utils/plugin-manager.ts
@@ -128,7 +128,7 @@ async function downloadFile(url: string, destination: string): Promise<void> {
         // Prepare request options with User-Agent for WP Rocket API
         const options = {
             headers: {
-                'User-Agent': 'WP-Rocket-E2E-Tests'
+                'User-Agent': 'WP-Rocket-E2E-Tests' // eslint-disable-line @typescript-eslint/naming-convention
             }
         };
         
@@ -214,8 +214,8 @@ async function downloadFromReleases(version: string, destination: string, repo?:
         // Download the source archive
         const downloadOptions = {
             headers: {
-                'User-Agent': 'WP-Rocket-E2E-Tests',
-                'Authorization': `Bearer ${token}`
+                'User-Agent': 'WP-Rocket-E2E-Tests', // eslint-disable-line @typescript-eslint/naming-convention
+                'Authorization': `Bearer ${token}` // eslint-disable-line @typescript-eslint/naming-convention
             }
         };
         

--- a/utils/plugin-manager.ts
+++ b/utils/plugin-manager.ts
@@ -1,0 +1,338 @@
+/**
+ * @fileoverview
+ * Plugin Manager for WP Rocket E2E tests.
+ * Automatically downloads or builds WP Rocket plugin versions based on configuration.
+ * 
+ * @requires {@link ../config/plugin.config}
+ */
+
+import fs from 'fs';
+import path from 'path';
+import https from 'https';
+import { exec } from 'child_process';
+import { promisify } from 'util';
+import { pluginConfig, forceRebuild, PluginVersionConfig } from '../config/plugin.config';
+
+const execAsync = promisify(exec);
+
+/**
+ * Plugin file mapping for different versions.
+ */
+const PLUGIN_FILES: Record<string, string> = {
+    previousStable: 'previous_stable.zip',
+    newRelease: 'new_release.zip',
+    specificVersion: 'wp-rocket_3.10.9.zip',
+};
+
+/**
+ * Plugin directory where zip files are stored.
+ */
+const PLUGIN_DIR = path.join(process.cwd(), 'plugin');
+
+/**
+ * Temporary directory for building plugins.
+ */
+const TEMP_DIR = path.join(process.cwd(), '.tmp-plugin-build');
+
+/**
+ * Ensures the plugin directory exists.
+ * 
+ * @return {Promise<void>}
+ */
+async function ensurePluginDir(): Promise<void> {
+    if (!fs.existsSync(PLUGIN_DIR)) {
+        fs.mkdirSync(PLUGIN_DIR, { recursive: true });
+    }
+}
+
+/**
+ * Checks if a plugin file exists.
+ * 
+ * @param {string} filename - Plugin filename to check
+ * @return {boolean} True if file exists
+ */
+function pluginFileExists(filename: string): boolean {
+    return fs.existsSync(path.join(PLUGIN_DIR, filename));
+}
+
+/**
+ * Downloads a file from a URL.
+ * 
+ * @param {string} url - URL to download from
+ * @param {string} destination - Destination file path
+ * @return {Promise<void>}
+ */
+async function downloadFile(url: string, destination: string): Promise<void> {
+    return new Promise((resolve, reject) => {
+        const file = fs.createWriteStream(destination);
+        
+        https.get(url, (response) => {
+            // Handle redirects
+            if (response.statusCode === 301 || response.statusCode === 302) {
+                file.close();
+                fs.unlinkSync(destination);
+                return downloadFile(response.headers.location!, destination)
+                    .then(resolve)
+                    .catch(reject);
+            }
+
+            if (response.statusCode !== 200) {
+                file.close();
+                fs.unlinkSync(destination);
+                return reject(new Error(`Failed to download: ${response.statusCode} ${response.statusMessage}`));
+            }
+
+            response.pipe(file);
+
+            file.on('finish', () => {
+                file.close();
+                resolve();
+            });
+        }).on('error', (err) => {
+            file.close();
+            if (fs.existsSync(destination)) {
+                fs.unlinkSync(destination);
+            }
+            reject(err);
+        });
+    });
+}
+
+/**
+ * Downloads a plugin version from WP Rocket releases.
+ * Note: This assumes public access to releases. Adjust if authentication is needed.
+ * 
+ * @param {string} version - Version number (e.g., '3.16.0')
+ * @param {string} destination - Destination file path
+ * @return {Promise<void>}
+ */
+async function downloadFromReleases(version: string, destination: string): Promise<void> {
+    // This URL structure may need to be adjusted based on actual WP Rocket release hosting
+    // For now, this is a placeholder structure
+    const url = `https://wp-rocket.me/releases/wp-rocket_${version}.zip`;
+    
+    console.log(`Downloading WP Rocket ${version} from releases...`);
+    await downloadFile(url, destination);
+    console.log(`✓ Downloaded WP Rocket ${version}`);
+}
+
+/**
+ * Clones and builds a plugin from a GitHub branch or tag.
+ * 
+ * @param {string} ref - Branch or tag name
+ * @param {string} destination - Destination zip file path
+ * @param {PluginVersionConfig['repository']} repo - Repository configuration
+ * @return {Promise<void>}
+ */
+async function buildFromGitHub(
+    ref: string,
+    destination: string,
+    repo?: PluginVersionConfig['repository']
+): Promise<void> {
+    if (!repo) {
+        throw new Error('Repository configuration is required for building from GitHub branches/tags');
+    }
+
+    const { owner, name, token } = repo;
+    const repoUrl = token 
+        ? `https://${token}@github.com/${owner}/${name}.git`
+        : `https://github.com/${owner}/${name}.git`;
+    
+    // Clean up temp directory if it exists
+    if (fs.existsSync(TEMP_DIR)) {
+        await execAsync(`rm -rf ${TEMP_DIR}`);
+    }
+    
+    fs.mkdirSync(TEMP_DIR, { recursive: true });
+    
+    try {
+        console.log(`Building WP Rocket from ${ref}...`);
+        
+        // Clone the repository
+        console.log('  Cloning repository...');
+        await execAsync(`git clone --depth 1 --branch ${ref} ${repoUrl} ${TEMP_DIR}`);
+        
+        // Check if composer.json exists and install dependencies
+        const composerFile = path.join(TEMP_DIR, 'composer.json');
+        if (fs.existsSync(composerFile)) {
+            console.log('  Installing Composer dependencies...');
+            await execAsync(`cd ${TEMP_DIR} && composer install --no-dev --optimize-autoloader`);
+        }
+        
+        // Check if package.json exists and build assets
+        const packageFile = path.join(TEMP_DIR, 'package.json');
+        if (fs.existsSync(packageFile)) {
+            console.log('  Building assets...');
+            await execAsync(`cd ${TEMP_DIR} && npm install && npm run build`);
+        }
+        
+        // Create zip file
+        console.log('  Creating zip file...');
+        const pluginDirName = name;
+        await execAsync(`cd ${TEMP_DIR}/.. && zip -r ${destination} ${path.basename(TEMP_DIR)} -x "*.git*" "node_modules/*" "tests/*" "*.md"`);
+        
+        console.log(`✓ Built WP Rocket from ${ref}`);
+    } finally {
+        // Clean up temp directory
+        if (fs.existsSync(TEMP_DIR)) {
+            await execAsync(`rm -rf ${TEMP_DIR}`);
+        }
+    }
+}
+
+/**
+ * Processes a version configuration and downloads/builds the plugin if needed.
+ * 
+ * @param {string} versionConfig - Version configuration (version number, branch:name, tag:name, or URL)
+ * @param {string} targetFilename - Target filename in plugin directory
+ * @param {PluginVersionConfig['repository']} repo - Repository configuration
+ * @return {Promise<void>}
+ */
+async function processVersion(
+    versionConfig: string,
+    targetFilename: string,
+    repo?: PluginVersionConfig['repository']
+): Promise<void> {
+    const targetPath = path.join(PLUGIN_DIR, targetFilename);
+    
+    // Check if file already exists and we're not forcing rebuild
+    if (!forceRebuild && pluginFileExists(targetFilename)) {
+        console.log(`✓ ${targetFilename} already exists (use --force-plugin-rebuild to rebuild)`);
+        return;
+    }
+    
+    // Handle different version config formats
+    if (versionConfig.startsWith('http://') || versionConfig.startsWith('https://')) {
+        // Direct URL download
+        await downloadFile(versionConfig, targetPath);
+    } else if (versionConfig.startsWith('branch:')) {
+        // GitHub branch
+        const branch = versionConfig.replace('branch:', '');
+        await buildFromGitHub(branch, targetPath, repo);
+    } else if (versionConfig.startsWith('tag:')) {
+        // GitHub tag
+        const tag = versionConfig.replace('tag:', '');
+        await buildFromGitHub(tag, targetPath, repo);
+    } else {
+        // Assume it's a version number
+        await downloadFromReleases(versionConfig, targetPath);
+    }
+}
+
+/**
+ * Sets up all required plugin versions based on configuration.
+ * 
+ * @param {boolean} force - Force rebuild even if files exist
+ * @return {Promise<void>}
+ */
+export async function setupPluginVersions(force: boolean = false): Promise<void> {
+    console.log('\n🚀 WP Rocket Plugin Manager\n');
+    console.log('Setting up plugin versions...\n');
+    
+    try {
+        await ensurePluginDir();
+        
+        // Process each version
+        await processVersion(
+            pluginConfig.previousStable,
+            PLUGIN_FILES.previousStable,
+            pluginConfig.repository
+        );
+        
+        await processVersion(
+            pluginConfig.newRelease,
+            PLUGIN_FILES.newRelease,
+            pluginConfig.repository
+        );
+        
+        if (pluginConfig.specificVersion) {
+            await processVersion(
+                pluginConfig.specificVersion,
+                PLUGIN_FILES.specificVersion,
+                pluginConfig.repository
+            );
+        }
+        
+        console.log('\n✅ Plugin setup completed successfully!\n');
+    } catch (error) {
+        console.error('\n❌ Plugin setup failed:', error.message);
+        throw error;
+    }
+}
+
+/**
+ * Validates that all required plugin files exist.
+ * 
+ * @return {Promise<boolean>} True if all required files exist
+ */
+export async function validatePluginFiles(): Promise<boolean> {
+    const requiredFiles = [
+        PLUGIN_FILES.previousStable,
+        PLUGIN_FILES.newRelease,
+    ];
+    
+    if (pluginConfig.specificVersion) {
+        requiredFiles.push(PLUGIN_FILES.specificVersion);
+    }
+    
+    const missingFiles = requiredFiles.filter(file => !pluginFileExists(file));
+    
+    if (missingFiles.length > 0) {
+        console.warn('⚠️  Missing plugin files:', missingFiles);
+        return false;
+    }
+    
+    return true;
+}
+
+/**
+ * Lists all plugin files in the plugin directory with their versions.
+ * 
+ * @return {Promise<void>}
+ */
+export async function listPluginFiles(): Promise<void> {
+    console.log('\n📦 Plugin Files:\n');
+    
+    const files = [
+        { name: PLUGIN_FILES.previousStable, config: pluginConfig.previousStable },
+        { name: PLUGIN_FILES.newRelease, config: pluginConfig.newRelease },
+        { name: PLUGIN_FILES.specificVersion, config: pluginConfig.specificVersion },
+    ];
+    
+    for (const file of files) {
+        const exists = pluginFileExists(file.name);
+        const status = exists ? '✓' : '✗';
+        const size = exists 
+            ? (fs.statSync(path.join(PLUGIN_DIR, file.name)).size / 1024 / 1024).toFixed(2) + ' MB'
+            : 'N/A';
+        
+        console.log(`${status} ${file.name.padEnd(30)} (${file.config}) - ${size}`);
+    }
+    
+    console.log();
+}
+
+/**
+ * Cleans up all plugin files.
+ * 
+ * @return {Promise<void>}
+ */
+export async function cleanPluginFiles(): Promise<void> {
+    console.log('\n🧹 Cleaning plugin files...\n');
+    
+    const files = [
+        PLUGIN_FILES.previousStable,
+        PLUGIN_FILES.newRelease,
+        PLUGIN_FILES.specificVersion,
+    ];
+    
+    for (const file of files) {
+        const filePath = path.join(PLUGIN_DIR, file);
+        if (fs.existsSync(filePath)) {
+            fs.unlinkSync(filePath);
+            console.log(`✓ Deleted ${file}`);
+        }
+    }
+    
+    console.log('\n✅ Cleanup completed!\n');
+}

--- a/utils/plugin-manager.ts
+++ b/utils/plugin-manager.ts
@@ -11,9 +11,24 @@ import path from 'path';
 import https from 'https';
 import { exec } from 'child_process';
 import { promisify } from 'util';
-import { pluginConfig, forceRebuild, PluginVersionConfig } from '../config/plugin.config';
 
 const execAsync = promisify(exec);
+
+// Gracefully handle missing config/plugin.config.ts
+let pluginConfig: PluginVersionConfig;
+
+try {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const config = require('../config/plugin.config');
+    pluginConfig = config.pluginConfig;
+} catch (error) {
+    console.error('❌ Plugin configuration not found!');
+    console.error('Please copy config/plugin.config.sample.ts to config/plugin.config.ts and configure your plugin versions.');
+    process.exit(1);
+}
+
+// Import type separately
+import type { PluginVersionConfig } from '../config/plugin.config';
 
 /**
  * Plugin file mapping for different versions.
@@ -33,6 +48,12 @@ const PLUGIN_DIR = path.join(process.cwd(), 'plugin');
  * Temporary directory for building plugins.
  */
 const TEMP_DIR = path.join(process.cwd(), '.tmp-plugin-build');
+
+/**
+ * Global flag to track whether to force rebuild.
+ * Used internally by processVersion to check against CLI/hook parameter.
+ */
+let shouldForceRebuild = false;
 
 /**
  * Ensures the plugin directory exists.
@@ -63,6 +84,13 @@ function pluginFileExists(filename: string): boolean {
  * @return {Promise<void>}
  */
 async function downloadFile(url: string, destination: string): Promise<void> {
+    // Validate destination is within allowed directory
+    const resolvedDest = path.resolve(destination);
+    const pluginDir = path.resolve(PLUGIN_DIR);
+    if (!resolvedDest.startsWith(pluginDir + path.sep)) {
+        throw new Error('Invalid destination path: must be within plugin directory');
+    }
+    
     return new Promise((resolve, reject) => {
         const file = fs.createWriteStream(destination);
         
@@ -71,7 +99,11 @@ async function downloadFile(url: string, destination: string): Promise<void> {
             if (response.statusCode === 301 || response.statusCode === 302) {
                 file.close();
                 fs.unlinkSync(destination);
-                return downloadFile(response.headers.location!, destination)
+                const redirectUrl = response.headers.location;
+                if (!redirectUrl) {
+                    return reject(new Error('Redirect response missing Location header'));
+                }
+                return downloadFile(redirectUrl, destination)
                     .then(resolve)
                     .catch(reject);
             }
@@ -90,8 +122,10 @@ async function downloadFile(url: string, destination: string): Promise<void> {
             });
         }).on('error', (err) => {
             file.close();
-            if (fs.existsSync(destination)) {
+            try {
                 fs.unlinkSync(destination);
+            } catch {
+                // File may not exist, ignore
             }
             reject(err);
         });
@@ -107,6 +141,11 @@ async function downloadFile(url: string, destination: string): Promise<void> {
  * @return {Promise<void>}
  */
 async function downloadFromReleases(version: string, destination: string): Promise<void> {
+    // Validate version format: allow alphanumeric, dots, underscores, and hyphens
+    if (!/^[\w.-]+$/.test(version)) {
+        throw new Error(`Invalid version format: ${version}`);
+    }
+    
     // This URL structure may need to be adjusted based on actual WP Rocket release hosting
     // For now, this is a placeholder structure
     const url = `https://wp-rocket.me/releases/wp-rocket_${version}.zip`;
@@ -114,6 +153,34 @@ async function downloadFromReleases(version: string, destination: string): Promi
     console.log(`Downloading WP Rocket ${version} from releases...`);
     await downloadFile(url, destination);
     console.log(`✓ Downloaded WP Rocket ${version}`);
+}
+
+/**
+ * Sanitizes a string for use in shell commands.
+ * Validates against allowed patterns to prevent command injection.
+ * 
+ * @param {string} input - Input string to sanitize
+ * @param {string} type - Type of input ('ref', 'path', or 'url')
+ * @return {string} Sanitized string
+ */
+function sanitizeShellInput(input: string, type: 'ref' | 'path' | 'url'): string {
+    if (type === 'ref') {
+        // Branch/tag names should only contain safe characters
+        if (!/^[a-zA-Z0-9/_.-]+$/.test(input)) {
+            throw new Error(`Invalid ref name: ${input}. Only alphanumeric, /, _, ., and - are allowed.`);
+        }
+    } else if (type === 'path') {
+        // Paths should not contain suspicious patterns
+        if (input.includes(';') || input.includes('|') || input.includes('&') || input.includes('`')) {
+            throw new Error(`Invalid path: ${input}. Contains suspicious characters.`);
+        }
+    } else if (type === 'url') {
+        // URLs should start with https://
+        if (!input.startsWith('https://') && !input.startsWith('http://')) {
+            throw new Error(`Invalid URL: ${input}. Must start with http:// or https://.`);
+        }
+    }
+    return input;
 }
 
 /**
@@ -133,14 +200,19 @@ async function buildFromGitHub(
         throw new Error('Repository configuration is required for building from GitHub branches/tags');
     }
 
+    // Validate inputs to prevent command injection
+    const sanitizedRef = sanitizeShellInput(ref, 'ref');
+    const sanitizedDestination = sanitizeShellInput(destination, 'path');
+    
     const { owner, name, token } = repo;
-    const repoUrl = token 
-        ? `https://${token}@github.com/${owner}/${name}.git`
-        : `https://github.com/${owner}/${name}.git`;
+    
+    // Use git credential helper or SSH instead of embedding token in URL
+    // Note: For security, consider using SSH keys or git credential helpers
+    const repoUrl = `https://github.com/${owner}/${name}.git`;
     
     // Clean up temp directory if it exists
     if (fs.existsSync(TEMP_DIR)) {
-        await execAsync(`rm -rf ${TEMP_DIR}`);
+        await execAsync(`rm -rf "${TEMP_DIR}"`);
     }
     
     fs.mkdirSync(TEMP_DIR, { recursive: true });
@@ -150,32 +222,52 @@ async function buildFromGitHub(
         
         // Clone the repository
         console.log('  Cloning repository...');
-        await execAsync(`git clone --depth 1 --branch ${ref} ${repoUrl} ${TEMP_DIR}`);
+        
+        // If token provided, configure git credential for this clone operation
+        let cloneCmd = `git clone --depth 1 --branch "${sanitizedRef}" ${repoUrl} "${TEMP_DIR}"`;
+        if (token) {
+            // Use GIT_ASKPASS to provide token securely without exposing in URL
+            const tokenFile = path.join(TEMP_DIR, '..', '.git-credentials-temp');
+            fs.writeFileSync(tokenFile, `https://${token}:x-oauth-basic@github.com`, { mode: 0o600 });
+            cloneCmd = `GIT_TERMINAL_PROMPT=0 git -c credential.helper="store --file=${tokenFile}" clone --depth 1 --branch "${sanitizedRef}" ${repoUrl} "${TEMP_DIR}"`;
+            
+            try {
+                await execAsync(cloneCmd);
+            } finally {
+                // Clean up credential file immediately after clone
+                if (fs.existsSync(tokenFile)) {
+                    fs.unlinkSync(tokenFile);
+                }
+            }
+        } else {
+            await execAsync(cloneCmd);
+        }
         
         // Check if composer.json exists and install dependencies
         const composerFile = path.join(TEMP_DIR, 'composer.json');
         if (fs.existsSync(composerFile)) {
             console.log('  Installing Composer dependencies...');
-            await execAsync(`cd ${TEMP_DIR} && composer install --no-dev --optimize-autoloader`);
+            await execAsync(`cd "${TEMP_DIR}" && composer install --no-dev --optimize-autoloader`);
         }
         
         // Check if package.json exists and build assets
         const packageFile = path.join(TEMP_DIR, 'package.json');
         if (fs.existsSync(packageFile)) {
             console.log('  Building assets...');
-            await execAsync(`cd ${TEMP_DIR} && npm install && npm run build`);
+            await execAsync(`cd "${TEMP_DIR}" && npm install && npm run build`);
         }
         
         // Create zip file
         console.log('  Creating zip file...');
-        const pluginDirName = name;
-        await execAsync(`cd ${TEMP_DIR}/.. && zip -r ${destination} ${path.basename(TEMP_DIR)} -x "*.git*" "node_modules/*" "tests/*" "*.md"`);
+        const tempParent = path.dirname(TEMP_DIR);
+        const tempBasename = path.basename(TEMP_DIR);
+        await execAsync(`cd "${tempParent}" && zip -r "${sanitizedDestination}" "${tempBasename}" -x "*.git*" "node_modules/*" "tests/*" "*.md"`);
         
         console.log(`✓ Built WP Rocket from ${ref}`);
     } finally {
         // Clean up temp directory
         if (fs.existsSync(TEMP_DIR)) {
-            await execAsync(`rm -rf ${TEMP_DIR}`);
+            await execAsync(`rm -rf "${TEMP_DIR}"`);
         }
     }
 }
@@ -196,8 +288,8 @@ async function processVersion(
     const targetPath = path.join(PLUGIN_DIR, targetFilename);
     
     // Check if file already exists and we're not forcing rebuild
-    if (!forceRebuild && pluginFileExists(targetFilename)) {
-        console.log(`✓ ${targetFilename} already exists (use --force-plugin-rebuild to rebuild)`);
+    if (!shouldForceRebuild && pluginFileExists(targetFilename)) {
+        console.log(`✓ ${targetFilename} already exists (use --force to rebuild)`);
         return;
     }
     
@@ -229,6 +321,9 @@ export async function setupPluginVersions(force: boolean = false): Promise<void>
     console.log('\n🚀 WP Rocket Plugin Manager\n');
     console.log('Setting up plugin versions...\n');
     
+    // Set the internal flag based on parameter
+    shouldForceRebuild = force;
+    
     try {
         await ensurePluginDir();
         
@@ -255,7 +350,8 @@ export async function setupPluginVersions(force: boolean = false): Promise<void>
         
         console.log('\n✅ Plugin setup completed successfully!\n');
     } catch (error) {
-        console.error('\n❌ Plugin setup failed:', error.message);
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        console.error('\n❌ Plugin setup failed:', errorMessage);
         throw error;
     }
 }

--- a/utils/plugin-manager.ts
+++ b/utils/plugin-manager.ts
@@ -307,16 +307,16 @@ async function processVersion(
 ): Promise<void> {
     const targetPath = path.join(PLUGIN_DIR, targetFilename);
     
-    // Checkt labelInfo = label ? ` (${label})` : '';
+    // Check if file already exists and we're not forcing rebuild
+    if (!shouldForceRebuild && pluginFileExists(targetFilename)) {
+        const labelInfo = label ? ` (${label})` : '';
         console.log(`✓ ${targetFilename}${labelInfo} already exists (use --force to rebuild)`);
         return;
     }
     
     // Log which version we're processing
     if (label) {
-        console.log(`\nProcessing ${label}: ${versionConfig}`)dForceRebuild && pluginFileExists(targetFilename)) {
-        console.log(`✓ ${targetFilename} already exists (use --force to rebuild)`);
-        return;
+        console.log(`\nProcessing ${label}: ${versionConfig}`);
     }
     
     // Handle different version config formats
@@ -333,7 +333,15 @@ async function processVersion(
         await buildFromGitHub(tag, targetPath, repo);
     } else {
         // Assume it's a version number
-    param {VersionOverrides} overrides - Optional version overrides from CLI/env
+        await downloadFromReleases(versionConfig, targetPath);
+    }
+}
+
+/**
+ * Sets up all required plugin versions based on configuration.
+ * 
+ * @param {boolean} force - Force rebuild even if files exist
+ * @param {VersionOverrides} overrides - Optional version overrides from CLI/env
  * @return {Promise<void>}
  */
 export async function setupPluginVersions(force: boolean = false, overrides?: VersionOverrides): Promise<void> {
@@ -379,14 +387,6 @@ export async function setupPluginVersions(force: boolean = false, overrides?: Ve
                 PLUGIN_FILES.specificVersion,
                 pluginConfig.repository,
                 'specific_version'
-            pluginConfig.repository
-        );
-        
-        if (pluginConfig.specificVersion) {
-            await processVersion(
-                pluginConfig.specificVersion,
-                PLUGIN_FILES.specificVersion,
-                pluginConfig.repository
             );
         }
         
@@ -402,26 +402,14 @@ export async function setupPluginVersions(force: boolean = false, overrides?: Ve
  * Validates that all required plugin files exist.
  * 
  * @return {Promise<boolean>} True if all required files exist
- */param {VersionOverrides} overrides - Optional version overrides to display
- * @return {Promise<void>}
  */
-export async function listPluginFiles(overrides?: VersionOverrides): Promise<void> {
-    console.log('\n📦 Plugin Files:\n');
-    
-    // Get active config with overrides applied
-    const pluginConfig = getActivePluginConfig(overrides);
-    
-    // Show override information if any
-    const runtimeOverrides = overrides || parseVersionOverrides();
-    if (hasVersionOverrides(runtimeOverrides)) {
-        console.log('📝 Active CLI Overrides:');
-        console.log(formatVersionOverrides(runtimeOverrides));
-        console.log();
-    }
+export async function validatePluginFiles(): Promise<boolean> {
+    const requiredFiles = [
+        PLUGIN_FILES.previousStable,
         PLUGIN_FILES.newRelease,
     ];
     
-    if (pluginConfig.specificVersion) {
+    if (basePluginConfig.specificVersion) {
         requiredFiles.push(PLUGIN_FILES.specificVersion);
     }
     
@@ -438,10 +426,22 @@ export async function listPluginFiles(overrides?: VersionOverrides): Promise<voi
 /**
  * Lists all plugin files in the plugin directory with their versions.
  * 
+ * @param {VersionOverrides} overrides - Optional version overrides to display
  * @return {Promise<void>}
  */
-export async function listPluginFiles(): Promise<void> {
+export async function listPluginFiles(overrides?: VersionOverrides): Promise<void> {
     console.log('\n📦 Plugin Files:\n');
+    
+    // Get active config with overrides applied
+    const pluginConfig = getActivePluginConfig(overrides);
+    
+    // Show override information if any
+    const runtimeOverrides = overrides || parseVersionOverrides();
+    if (hasVersionOverrides(runtimeOverrides)) {
+        console.log('📝 Active CLI Overrides:');
+        console.log(formatVersionOverrides(runtimeOverrides));
+        console.log();
+    }
     
     const files = [
         { name: PLUGIN_FILES.previousStable, config: pluginConfig.previousStable },

--- a/utils/plugin-manager.ts
+++ b/utils/plugin-manager.ts
@@ -171,7 +171,7 @@ async function downloadFile(url: string, destination: string): Promise<void> {
 }
 
 /**
- * Downloads a plugin version from GitHub releases.
+ * Downloads a plugin version from GitHub releases and builds it.
  * Requires GITHUB_TOKEN environment variable for authentication.
  * 
  * @param {string} version - Version number (e.g., '3.16.0')
@@ -201,69 +201,140 @@ async function downloadFromReleases(version: string, destination: string, repo?:
     
     console.log(`Downloading WP Rocket ${version} from GitHub releases...`);
     
-    // Download the source archive
-    const downloadOptions = {
-        headers: {
-            'User-Agent': 'WP-Rocket-E2E-Tests',
-            'Authorization': `Bearer ${token}`
-        }
-    };
+    // Create temp directory for extraction
+    const extractDir = path.join(TEMP_DIR, `${name}-${version}`);
+    if (fs.existsSync(extractDir)) {
+        await execAsync(`rm -rf "${extractDir}"`);
+    }
+    fs.mkdirSync(extractDir, { recursive: true });
     
-    await new Promise<void>((resolve, reject) => {
-        const file = fs.createWriteStream(destination);
+    const tempZip = path.join(TEMP_DIR, `${name}-${version}-source.zip`);
+    
+    try {
+        // Download the source archive
+        const downloadOptions = {
+            headers: {
+                'User-Agent': 'WP-Rocket-E2E-Tests',
+                'Authorization': `Bearer ${token}`
+            }
+        };
         
-        https.get(archiveUrl, downloadOptions, (response) => {
-            // Handle redirects
-            if (response.statusCode === 301 || response.statusCode === 302) {
-                file.close();
-                fs.unlinkSync(destination);
-                const redirectUrl = response.headers.location;
-                if (!redirectUrl) {
-                    return reject(new Error('Redirect response missing Location header'));
-                }
-                
-                // Follow redirect without auth headers (GitHub redirects to public CDN)
-                https.get(redirectUrl, (redirectResponse) => {
-                    if (redirectResponse.statusCode !== 200) {
-                        return reject(new Error(`Failed to download: ${redirectResponse.statusCode}`));
+        await new Promise<void>((resolve, reject) => {
+            const file = fs.createWriteStream(tempZip);
+            
+            https.get(archiveUrl, downloadOptions, (response) => {
+                // Handle redirects
+                if (response.statusCode === 301 || response.statusCode === 302) {
+                    file.close();
+                    fs.unlinkSync(tempZip);
+                    const redirectUrl = response.headers.location;
+                    if (!redirectUrl) {
+                        return reject(new Error('Redirect response missing Location header'));
                     }
                     
-                    const newFile = fs.createWriteStream(destination);
-                    redirectResponse.pipe(newFile);
+                    // Follow redirect without auth headers (GitHub redirects to public CDN)
+                    https.get(redirectUrl, (redirectResponse) => {
+                        if (redirectResponse.statusCode !== 200) {
+                            return reject(new Error(`Failed to download: ${redirectResponse.statusCode}`));
+                        }
+                        
+                        const newFile = fs.createWriteStream(tempZip);
+                        redirectResponse.pipe(newFile);
+                        
+                        newFile.on('finish', () => {
+                            newFile.close();
+                            resolve();
+                        });
+                    }).on('error', reject);
                     
-                    newFile.on('finish', () => {
-                        newFile.close();
-                        resolve();
-                    });
-                }).on('error', reject);
-                
-                return;
-            }
+                    return;
+                }
 
-            if (response.statusCode !== 200) {
+                if (response.statusCode !== 200) {
+                    file.close();
+                    fs.unlinkSync(tempZip);
+                    return reject(new Error(`Failed to download: ${response.statusCode} ${response.statusMessage}`));
+                }
+
+                response.pipe(file);
+
+                file.on('finish', () => {
+                    file.close();
+                    resolve();
+                });
+            }).on('error', (err) => {
                 file.close();
-                fs.unlinkSync(destination);
-                return reject(new Error(`Failed to download: ${response.statusCode} ${response.statusMessage}`));
-            }
-
-            response.pipe(file);
-
-            file.on('finish', () => {
-                file.close();
-                resolve();
+                try {
+                    fs.unlinkSync(tempZip);
+                } catch {
+                    // File may not exist, ignore
+                }
+                reject(err);
             });
-        }).on('error', (err) => {
-            file.close();
-            try {
-                fs.unlinkSync(destination);
-            } catch {
-                // File may not exist, ignore
-            }
-            reject(err);
         });
-    });
-    
-    console.log(`✓ Downloaded WP Rocket ${version}`);
+        
+        console.log('  Extracting source archive...');
+        await execAsync(`unzip -q "${tempZip}" -d "${extractDir}"`);
+        
+        // GitHub archives extract to a folder named "repo-name-tag"
+        // Find the extracted directory
+        const extractedDirs = fs.readdirSync(extractDir);
+        if (extractedDirs.length === 0) {
+            throw new Error('No files extracted from archive');
+        }
+        const sourceDir = path.join(extractDir, extractedDirs[0]);
+        
+        // Check if composer.json exists and install dependencies
+        const composerFile = path.join(sourceDir, 'composer.json');
+        if (fs.existsSync(composerFile)) {
+            console.log('  Installing Composer dependencies...');
+            // Install without dev dependencies and skip scripts that require dev tools
+            await execAsync(`cd "${sourceDir}" && composer install --no-dev --optimize-autoloader --no-scripts 2>&1`);
+            // Manually generate optimized autoloader
+            await execAsync(`cd "${sourceDir}" && composer dump-autoload --no-dev --optimize 2>&1`);
+        }
+        
+        // Check if package.json exists and install npm dependencies
+        const packageFile = path.join(sourceDir, 'package.json');
+        if (fs.existsSync(packageFile)) {
+            console.log('  Installing npm dependencies...');
+            await execAsync(`cd "${sourceDir}" && npm install`);
+            
+            // Check if there's a build script
+            const packageJson = JSON.parse(fs.readFileSync(packageFile, 'utf-8'));
+            if (packageJson.scripts?.build || packageJson.scripts?.['build:css'] || packageJson.scripts?.['build:js']) {
+                console.log('  Building assets...');
+                // Try build script first, fallback to specific build scripts
+                if (packageJson.scripts.build) {
+                    await execAsync(`cd "${sourceDir}" && npm run build`);
+                } else {
+                    if (packageJson.scripts['build:css']) {
+                        await execAsync(`cd "${sourceDir}" && npm run build:css`);
+                    }
+                    if (packageJson.scripts['build:js']) {
+                        await execAsync(`cd "${sourceDir}" && npm run build:js`);
+                    }
+                }
+            }
+        }
+        
+        // Create zip file from the built source
+        console.log('  Creating plugin zip...');
+        const sourceBasename = path.basename(sourceDir);
+        const sourceParent = path.dirname(sourceDir);
+        await execAsync(`cd "${sourceParent}" && zip -q -r "${destination}" "${sourceBasename}" -x "*.git*" "node_modules/*" "tests/*" "*.md"`);
+        
+        console.log(`✓ Downloaded and built WP Rocket ${version}`);
+        
+    } finally {
+        // Clean up temp files
+        if (fs.existsSync(tempZip)) {
+            fs.unlinkSync(tempZip);
+        }
+        if (fs.existsSync(extractDir)) {
+            await execAsync(`rm -rf "${extractDir}"`);
+        }
+    }
 }
 
 /**

--- a/utils/plugin-manager.ts
+++ b/utils/plugin-manager.ts
@@ -17,28 +17,42 @@ import type { VersionOverrides } from './version-override';
 const execAsync = promisify(exec);
 
 // Gracefully handle missing config/plugin.config.ts
-let basePluginConfig: PluginVersionConfig;
+let basePluginConfig: PluginVersionConfig | null = null;
+let hasPluginConfig = false;
 
 try {
     // eslint-disable-next-line @typescript-eslint/no-var-requires
     const config = require('../config/plugin.config');
     basePluginConfig = config.pluginConfig;
+    hasPluginConfig = true;
 } catch (error) {
-    console.error('❌ Plugin configuration not found!');
-    console.error('Please copy config/plugin.config.sample.ts to config/plugin.config.ts and configure your plugin versions.');
-    process.exit(1);
+    // Config file not found - this is OK if CLI overrides are provided or using existing plugins
+    hasPluginConfig = false;
 }
 
 // Import type separately
 import type { PluginVersionConfig } from '../config/plugin.config';
 
 /**
+ * Checks if plugin config file exists.
+ * 
+ * @return {boolean} True if config file exists
+ */
+export function hasPluginConfigFile(): boolean {
+    return hasPluginConfig;
+}
+
+/**
  * Gets the active plugin configuration with any CLI overrides applied.
  * 
  * @param {VersionOverrides} overrides - Optional version overrides to apply
- * @return {PluginVersionConfig} Active plugin configuration
+ * @return {PluginVersionConfig | null} Active plugin configuration or null if no config
  */
-function getActivePluginConfig(overrides?: VersionOverrides): PluginVersionConfig {
+function getActivePluginConfig(overrides?: VersionOverrides): PluginVersionConfig | null {
+    if (!basePluginConfig) {
+        return null;
+    }
+    
     const runtimeOverrides = overrides || parseVersionOverrides();
     
     if (hasVersionOverrides(runtimeOverrides)) {
@@ -409,7 +423,7 @@ export async function validatePluginFiles(): Promise<boolean> {
         PLUGIN_FILES.newRelease,
     ];
     
-    if (basePluginConfig.specificVersion) {
+    if (basePluginConfig?.specificVersion) {
         requiredFiles.push(PLUGIN_FILES.specificVersion);
     }
     

--- a/utils/plugin-manager.ts
+++ b/utils/plugin-manager.ts
@@ -11,16 +11,18 @@ import path from 'path';
 import https from 'https';
 import { exec } from 'child_process';
 import { promisify } from 'util';
+import { parseVersionOverrides, applyVersionOverrides, hasVersionOverrides, formatVersionOverrides } from './version-override';
+import type { VersionOverrides } from './version-override';
 
 const execAsync = promisify(exec);
 
 // Gracefully handle missing config/plugin.config.ts
-let pluginConfig: PluginVersionConfig;
+let basePluginConfig: PluginVersionConfig;
 
 try {
     // eslint-disable-next-line @typescript-eslint/no-var-requires
     const config = require('../config/plugin.config');
-    pluginConfig = config.pluginConfig;
+    basePluginConfig = config.pluginConfig;
 } catch (error) {
     console.error('❌ Plugin configuration not found!');
     console.error('Please copy config/plugin.config.sample.ts to config/plugin.config.ts and configure your plugin versions.');
@@ -29,6 +31,22 @@ try {
 
 // Import type separately
 import type { PluginVersionConfig } from '../config/plugin.config';
+
+/**
+ * Gets the active plugin configuration with any CLI overrides applied.
+ * 
+ * @param {VersionOverrides} overrides - Optional version overrides to apply
+ * @return {PluginVersionConfig} Active plugin configuration
+ */
+function getActivePluginConfig(overrides?: VersionOverrides): PluginVersionConfig {
+    const runtimeOverrides = overrides || parseVersionOverrides();
+    
+    if (hasVersionOverrides(runtimeOverrides)) {
+        return applyVersionOverrides(basePluginConfig, runtimeOverrides);
+    }
+    
+    return basePluginConfig;
+}
 
 /**
  * Plugin file mapping for different versions.
@@ -278,17 +296,25 @@ async function buildFromGitHub(
  * @param {string} versionConfig - Version configuration (version number, branch:name, tag:name, or URL)
  * @param {string} targetFilename - Target filename in plugin directory
  * @param {PluginVersionConfig['repository']} repo - Repository configuration
+ * @param {string} label - Label for logging purposes (e.g., 'previous_stable', 'new_release')
  * @return {Promise<void>}
  */
 async function processVersion(
     versionConfig: string,
     targetFilename: string,
-    repo?: PluginVersionConfig['repository']
+    repo?: PluginVersionConfig['repository'],
+    label?: string
 ): Promise<void> {
     const targetPath = path.join(PLUGIN_DIR, targetFilename);
     
-    // Check if file already exists and we're not forcing rebuild
-    if (!shouldForceRebuild && pluginFileExists(targetFilename)) {
+    // Checkt labelInfo = label ? ` (${label})` : '';
+        console.log(`✓ ${targetFilename}${labelInfo} already exists (use --force to rebuild)`);
+        return;
+    }
+    
+    // Log which version we're processing
+    if (label) {
+        console.log(`\nProcessing ${label}: ${versionConfig}`)dForceRebuild && pluginFileExists(targetFilename)) {
         console.log(`✓ ${targetFilename} already exists (use --force to rebuild)`);
         return;
     }
@@ -307,18 +333,23 @@ async function processVersion(
         await buildFromGitHub(tag, targetPath, repo);
     } else {
         // Assume it's a version number
-        await downloadFromReleases(versionConfig, targetPath);
-    }
-}
-
-/**
- * Sets up all required plugin versions based on configuration.
- * 
- * @param {boolean} force - Force rebuild even if files exist
+    param {VersionOverrides} overrides - Optional version overrides from CLI/env
  * @return {Promise<void>}
  */
-export async function setupPluginVersions(force: boolean = false): Promise<void> {
+export async function setupPluginVersions(force: boolean = false, overrides?: VersionOverrides): Promise<void> {
     console.log('\n🚀 WP Rocket Plugin Manager\n');
+    
+    // Get active config with overrides applied
+    const pluginConfig = getActivePluginConfig(overrides);
+    
+    // Show override information if any
+    const runtimeOverrides = overrides || parseVersionOverrides();
+    if (hasVersionOverrides(runtimeOverrides)) {
+        console.log('📝 CLI Version Overrides Detected:');
+        console.log(formatVersionOverrides(runtimeOverrides));
+        console.log();
+    }
+    
     console.log('Setting up plugin versions...\n');
     
     // Set the internal flag based on parameter
@@ -331,12 +362,23 @@ export async function setupPluginVersions(force: boolean = false): Promise<void>
         await processVersion(
             pluginConfig.previousStable,
             PLUGIN_FILES.previousStable,
-            pluginConfig.repository
+            pluginConfig.repository,
+            'previous_stable'
         );
         
         await processVersion(
             pluginConfig.newRelease,
             PLUGIN_FILES.newRelease,
+            pluginConfig.repository,
+            'new_release'
+        );
+        
+        if (pluginConfig.specificVersion) {
+            await processVersion(
+                pluginConfig.specificVersion,
+                PLUGIN_FILES.specificVersion,
+                pluginConfig.repository,
+                'specific_version'
             pluginConfig.repository
         );
         
@@ -360,10 +402,22 @@ export async function setupPluginVersions(force: boolean = false): Promise<void>
  * Validates that all required plugin files exist.
  * 
  * @return {Promise<boolean>} True if all required files exist
+ */param {VersionOverrides} overrides - Optional version overrides to display
+ * @return {Promise<void>}
  */
-export async function validatePluginFiles(): Promise<boolean> {
-    const requiredFiles = [
-        PLUGIN_FILES.previousStable,
+export async function listPluginFiles(overrides?: VersionOverrides): Promise<void> {
+    console.log('\n📦 Plugin Files:\n');
+    
+    // Get active config with overrides applied
+    const pluginConfig = getActivePluginConfig(overrides);
+    
+    // Show override information if any
+    const runtimeOverrides = overrides || parseVersionOverrides();
+    if (hasVersionOverrides(runtimeOverrides)) {
+        console.log('📝 Active CLI Overrides:');
+        console.log(formatVersionOverrides(runtimeOverrides));
+        console.log();
+    }
         PLUGIN_FILES.newRelease,
     ];
     

--- a/utils/plugin-manager.ts
+++ b/utils/plugin-manager.ts
@@ -68,7 +68,6 @@ function getActivePluginConfig(overrides?: VersionOverrides): PluginVersionConfi
 const PLUGIN_FILES: Record<string, string> = {
     previousStable: 'previous_stable.zip',
     newRelease: 'new_release.zip',
-    specificVersion: 'wp-rocket_3.10.9.zip',
 };
 
 /**
@@ -395,15 +394,7 @@ export async function setupPluginVersions(force: boolean = false, overrides?: Ve
             'new_release'
         );
         
-        if (pluginConfig.specificVersion) {
-            await processVersion(
-                pluginConfig.specificVersion,
-                PLUGIN_FILES.specificVersion,
-                pluginConfig.repository,
-                'specific_version'
-            );
-        }
-        
+
         console.log('\n✅ Plugin setup completed successfully!\n');
     } catch (error) {
         const errorMessage = error instanceof Error ? error.message : String(error);
@@ -422,10 +413,6 @@ export async function validatePluginFiles(): Promise<boolean> {
         PLUGIN_FILES.previousStable,
         PLUGIN_FILES.newRelease,
     ];
-    
-    if (basePluginConfig?.specificVersion) {
-        requiredFiles.push(PLUGIN_FILES.specificVersion);
-    }
     
     const missingFiles = requiredFiles.filter(file => !pluginFileExists(file));
     
@@ -460,7 +447,6 @@ export async function listPluginFiles(overrides?: VersionOverrides): Promise<voi
     const files = [
         { name: PLUGIN_FILES.previousStable, config: pluginConfig.previousStable },
         { name: PLUGIN_FILES.newRelease, config: pluginConfig.newRelease },
-        { name: PLUGIN_FILES.specificVersion, config: pluginConfig.specificVersion },
     ];
     
     for (const file of files) {
@@ -487,7 +473,6 @@ export async function cleanPluginFiles(): Promise<void> {
     const files = [
         PLUGIN_FILES.previousStable,
         PLUGIN_FILES.newRelease,
-        PLUGIN_FILES.specificVersion,
     ];
     
     for (const file of files) {

--- a/utils/plugin-manager.ts
+++ b/utils/plugin-manager.ts
@@ -125,7 +125,14 @@ async function downloadFile(url: string, destination: string): Promise<void> {
     return new Promise((resolve, reject) => {
         const file = fs.createWriteStream(destination);
         
-        https.get(url, (response) => {
+        // Prepare request options with User-Agent for WP Rocket API
+        const options = {
+            headers: {
+                'User-Agent': 'WP-Rocket-E2E-Tests'
+            }
+        };
+        
+        https.get(url, options, (response) => {
             // Handle redirects
             if (response.statusCode === 301 || response.statusCode === 302) {
                 file.close();
@@ -164,25 +171,98 @@ async function downloadFile(url: string, destination: string): Promise<void> {
 }
 
 /**
- * Downloads a plugin version from WP Rocket releases.
- * Note: This assumes public access to releases. Adjust if authentication is needed.
+ * Downloads a plugin version from GitHub releases.
+ * Requires GITHUB_TOKEN environment variable for authentication.
  * 
  * @param {string} version - Version number (e.g., '3.16.0')
  * @param {string} destination - Destination file path
+ * @param {PluginVersionConfig['repository']} repo - Repository configuration
  * @return {Promise<void>}
  */
-async function downloadFromReleases(version: string, destination: string): Promise<void> {
+async function downloadFromReleases(version: string, destination: string, repo?: PluginVersionConfig['repository']): Promise<void> {
     // Validate version format: allow alphanumeric, dots, underscores, and hyphens
     if (!/^[\w.-]+$/.test(version)) {
         throw new Error(`Invalid version format: ${version}`);
     }
     
-    // This URL structure may need to be adjusted based on actual WP Rocket release hosting
-    // For now, this is a placeholder structure
-    const url = `https://wp-rocket.me/releases/wp-rocket_${version}.zip`;
+    if (!repo) {
+        throw new Error('Repository configuration is required for downloading from GitHub releases. Please configure repository in plugin.config.ts');
+    }
     
-    console.log(`Downloading WP Rocket ${version} from releases...`);
-    await downloadFile(url, destination);
+    const { owner, name, token } = repo;
+    
+    if (!token) {
+        throw new Error('GITHUB_TOKEN is required for downloading from GitHub releases. Set it in your repository config or as an environment variable.');
+    }
+    
+    // GitHub automatically generates source archives for all tags
+    // Use the archive URL which is always available (tags always have 'v' prefix)
+    const archiveUrl = `https://github.com/${owner}/${name}/archive/refs/tags/v${version}.zip`;
+    
+    console.log(`Downloading WP Rocket ${version} from GitHub releases...`);
+    
+    // Download the source archive
+    const downloadOptions = {
+        headers: {
+            'User-Agent': 'WP-Rocket-E2E-Tests',
+            'Authorization': `Bearer ${token}`
+        }
+    };
+    
+    await new Promise<void>((resolve, reject) => {
+        const file = fs.createWriteStream(destination);
+        
+        https.get(archiveUrl, downloadOptions, (response) => {
+            // Handle redirects
+            if (response.statusCode === 301 || response.statusCode === 302) {
+                file.close();
+                fs.unlinkSync(destination);
+                const redirectUrl = response.headers.location;
+                if (!redirectUrl) {
+                    return reject(new Error('Redirect response missing Location header'));
+                }
+                
+                // Follow redirect without auth headers (GitHub redirects to public CDN)
+                https.get(redirectUrl, (redirectResponse) => {
+                    if (redirectResponse.statusCode !== 200) {
+                        return reject(new Error(`Failed to download: ${redirectResponse.statusCode}`));
+                    }
+                    
+                    const newFile = fs.createWriteStream(destination);
+                    redirectResponse.pipe(newFile);
+                    
+                    newFile.on('finish', () => {
+                        newFile.close();
+                        resolve();
+                    });
+                }).on('error', reject);
+                
+                return;
+            }
+
+            if (response.statusCode !== 200) {
+                file.close();
+                fs.unlinkSync(destination);
+                return reject(new Error(`Failed to download: ${response.statusCode} ${response.statusMessage}`));
+            }
+
+            response.pipe(file);
+
+            file.on('finish', () => {
+                file.close();
+                resolve();
+            });
+        }).on('error', (err) => {
+            file.close();
+            try {
+                fs.unlinkSync(destination);
+            } catch {
+                // File may not exist, ignore
+            }
+            reject(err);
+        });
+    });
+    
     console.log(`✓ Downloaded WP Rocket ${version}`);
 }
 
@@ -345,8 +425,8 @@ async function processVersion(
         const tag = versionConfig.replace('tag:', '');
         await buildFromGitHub(tag, targetPath, repo);
     } else {
-        // Assume it's a version number
-        await downloadFromReleases(versionConfig, targetPath);
+        // Assume it's a version number - download from GitHub releases
+        await downloadFromReleases(versionConfig, targetPath, repo);
     }
 }
 

--- a/utils/version-override.ts
+++ b/utils/version-override.ts
@@ -22,7 +22,6 @@
 export interface VersionOverrides {
     previousStable?: string;
     newRelease?: string;
-    specificVersion?: string;
 }
 
 /**
@@ -31,7 +30,6 @@ export interface VersionOverrides {
 export interface PluginVersionConfig {
     previousStable: string;
     newRelease: string;
-    specificVersion?: string;
     repository?: {
         owner: string;
         name: string;
@@ -52,9 +50,6 @@ function extractFromNpmConfig(overrides: VersionOverrides): void {
     if (process.env.npm_config_new_release) {
         overrides.newRelease = process.env.npm_config_new_release;
     }
-    if (process.env.npm_config_specific_version) {
-        overrides.specificVersion = process.env.npm_config_specific_version;
-    }
 }
 
 /**
@@ -69,9 +64,6 @@ function extractFromEnv(overrides: VersionOverrides): void {
     }
     if (process.env.NEW_RELEASE) {
         overrides.newRelease = process.env.NEW_RELEASE;
-    }
-    if (process.env.SPECIFIC_VERSION) {
-        overrides.specificVersion = process.env.SPECIFIC_VERSION;
     }
 }
 
@@ -111,9 +103,6 @@ function parseArgument(arg: string, args: string[], index: number, overrides: Ve
         return consumed;
     } else if (normalizedKey === 'newrelease') {
         overrides.newRelease = argValue;
-        return consumed;
-    } else if (normalizedKey === 'specificversion') {
-        overrides.specificVersion = argValue;
         return consumed;
     }
     
@@ -173,7 +162,6 @@ export function applyVersionOverrides(
         ...baseConfig,
         previousStable: overrides.previousStable || baseConfig.previousStable,
         newRelease: overrides.newRelease || baseConfig.newRelease,
-        specificVersion: overrides.specificVersion || baseConfig.specificVersion,
     };
 }
 
@@ -186,8 +174,7 @@ export function applyVersionOverrides(
 export function hasVersionOverrides(overrides: VersionOverrides): boolean {
     return !!(
         overrides.previousStable ||
-        overrides.newRelease ||
-        overrides.specificVersion
+        overrides.newRelease
     );
 }
 
@@ -205,9 +192,6 @@ export function formatVersionOverrides(overrides: VersionOverrides): string {
     }
     if (overrides.newRelease) {
         lines.push(`  new_release: ${overrides.newRelease}`);
-    }
-    if (overrides.specificVersion) {
-        lines.push(`  specific_version: ${overrides.specificVersion}`);
     }
     
     return lines.length > 0 ? lines.join('\n') : '  (none)';

--- a/utils/version-override.ts
+++ b/utils/version-override.ts
@@ -1,0 +1,214 @@
+/**
+ * @fileoverview
+ * Runtime plugin version override system for WP Rocket E2E tests.
+ * Allows passing plugin versions via CLI arguments without modifying config files.
+ * 
+ * @example
+ * # Override previous_stable version
+ * npm run test:e2e -- --previous-stable=3.16.0
+ * 
+ * @example
+ * # Override new_release version
+ * npm run test:e2e -- --new-release=branch:develop
+ * 
+ * @example
+ * # Override both versions
+ * npm run test:e2e -- --previous-stable=3.16.0 --new-release=3.16.1
+ */
+
+/**
+ * Interface for version overrides from CLI arguments.
+ */
+export interface VersionOverrides {
+    previousStable?: string;
+    newRelease?: string;
+    specificVersion?: string;
+}
+
+/**
+ * Interface for plugin version configuration (imported type).
+ */
+export interface PluginVersionConfig {
+    previousStable: string;
+    newRelease: string;
+    specificVersion?: string;
+    repository?: {
+        owner: string;
+        name: string;
+        token?: string;
+    };
+}
+
+/**
+ * Extracts version overrides from npm config environment variables.
+ * 
+ * @param {VersionOverrides} overrides - Overrides object to populate
+ * @return {void}
+ */
+function extractFromNpmConfig(overrides: VersionOverrides): void {
+    if (process.env.npm_config_previous_stable) {
+        overrides.previousStable = process.env.npm_config_previous_stable;
+    }
+    if (process.env.npm_config_new_release) {
+        overrides.newRelease = process.env.npm_config_new_release;
+    }
+    if (process.env.npm_config_specific_version) {
+        overrides.specificVersion = process.env.npm_config_specific_version;
+    }
+}
+
+/**
+ * Extracts version overrides from direct environment variables.
+ * 
+ * @param {VersionOverrides} overrides - Overrides object to populate
+ * @return {void}
+ */
+function extractFromEnv(overrides: VersionOverrides): void {
+    if (process.env.PREVIOUS_STABLE) {
+        overrides.previousStable = process.env.PREVIOUS_STABLE;
+    }
+    if (process.env.NEW_RELEASE) {
+        overrides.newRelease = process.env.NEW_RELEASE;
+    }
+    if (process.env.SPECIFIC_VERSION) {
+        overrides.specificVersion = process.env.SPECIFIC_VERSION;
+    }
+}
+
+/**
+ * Parses a command line argument in --key=value or --key value format.
+ * 
+ * @param {string} arg - The argument to parse
+ * @param {string[]} args - All arguments array
+ * @param {number} index - Current index in args array
+ * @param {VersionOverrides} overrides - Overrides object to populate
+ * @return {number} Number of arguments consumed (0 or 1 additional)
+ */
+// eslint-disable-next-line complexity
+function parseArgument(arg: string, args: string[], index: number, overrides: VersionOverrides): number {
+    if (!arg.startsWith('--')) {
+        return 0;
+    }
+    
+    const match = arg.match(/^--([^=]+)(?:=(.+))?$/);
+    if (!match) {
+        return 0;
+    }
+    
+    const [, key, value] = match;
+    const normalizedKey = key.toLowerCase().replace(/-/g, '');
+    
+    // Get value from next arg if not in --arg=value format
+    const argValue = value || args[index + 1];
+    if (!argValue) {
+        return 0;
+    }
+    
+    const consumed = value ? 0 : 1;
+    
+    if (normalizedKey === 'previousstable') {
+        overrides.previousStable = argValue;
+        return consumed;
+    } else if (normalizedKey === 'newrelease') {
+        overrides.newRelease = argValue;
+        return consumed;
+    } else if (normalizedKey === 'specificversion') {
+        overrides.specificVersion = argValue;
+        return consumed;
+    }
+    
+    return 0;
+}
+
+/**
+ * Extracts version overrides from process.argv command line arguments.
+ * 
+ * @param {VersionOverrides} overrides - Overrides object to populate
+ * @return {void}
+ */
+function extractFromArgv(overrides: VersionOverrides): void {
+    const args = process.argv.slice(2);
+    for (let i = 0; i < args.length; i++) {
+        const consumed = parseArgument(args[i], args, i, overrides);
+        i += consumed;
+    }
+}
+
+/**
+ * Parses CLI arguments to extract plugin version overrides.
+ * Supports multiple formats:
+ * - npm config style: --previous-stable=3.16.0 (via npm_config_previous_stable)
+ * - process.argv style: --previous-stable=3.16.0
+ * - environment variables: PREVIOUS_STABLE=3.16.0
+ * 
+ * @return {VersionOverrides} Parsed version overrides
+ */
+export function parseVersionOverrides(): VersionOverrides {
+    const overrides: VersionOverrides = {};
+    
+    // Check npm config variables (when using npm run test:e2e -- --arg=value)
+    extractFromNpmConfig(overrides);
+    
+    // Also check direct environment variables
+    extractFromEnv(overrides);
+    
+    // Parse process.argv for direct arguments
+    extractFromArgv(overrides);
+    
+    return overrides;
+}
+
+/**
+ * Applies version overrides to plugin configuration.
+ * 
+ * @param {PluginVersionConfig} baseConfig - Base configuration from config file
+ * @param {VersionOverrides} overrides - Version overrides from CLI/env
+ * @return {PluginVersionConfig} Merged configuration with overrides applied
+ */
+export function applyVersionOverrides(
+    baseConfig: PluginVersionConfig,
+    overrides: VersionOverrides
+): PluginVersionConfig {
+    return {
+        ...baseConfig,
+        previousStable: overrides.previousStable || baseConfig.previousStable,
+        newRelease: overrides.newRelease || baseConfig.newRelease,
+        specificVersion: overrides.specificVersion || baseConfig.specificVersion,
+    };
+}
+
+/**
+ * Checks if any version overrides are present.
+ * 
+ * @param {VersionOverrides} overrides - Version overrides to check
+ * @return {boolean} True if any overrides are present
+ */
+export function hasVersionOverrides(overrides: VersionOverrides): boolean {
+    return !!(
+        overrides.previousStable ||
+        overrides.newRelease ||
+        overrides.specificVersion
+    );
+}
+
+/**
+ * Formats version overrides for display.
+ * 
+ * @param {VersionOverrides} overrides - Version overrides to format
+ * @return {string} Formatted string of overrides
+ */
+export function formatVersionOverrides(overrides: VersionOverrides): string {
+    const lines: string[] = [];
+    
+    if (overrides.previousStable) {
+        lines.push(`  previous_stable: ${overrides.previousStable}`);
+    }
+    if (overrides.newRelease) {
+        lines.push(`  new_release: ${overrides.newRelease}`);
+    }
+    if (overrides.specificVersion) {
+        lines.push(`  specific_version: ${overrides.specificVersion}`);
+    }
+    
+    return lines.length > 0 ? lines.join('\n') : '  (none)';
+}


### PR DESCRIPTION
# Description

Fixes #6 
Eliminates manual plugin version management for E2E tests. QA engineers can now configure versions in `plugin.config.ts` and the framework automatically downloads/builds required files. Supports version numbers, GitHub branches/tags, and direct URLs. Tests auto-check and download missing plugins before running. Fully backward compatible, existing workflows continue to work unchanged.

## Type of change

- [x] Enhancement (non-breaking change which improves an existing functionality).

## Detailed scenario

### What was tested

All new `npm` commands

### How to test

1. Copy `config/plugin.config.sample.ts` to `config/plugin.config.ts`
2. Run `npm run plugin:setup` to download/build configured plugin versions
3. Verify with `npm run plugin:list` - should show 3 plugin files
4. Run `npm run test:e2e` to verify automatic plugin setup in tests
5. Test force rebuild: `npm run plugin:setup -- --force`
 
## Technical description

### Documentation

This pull request introduces automated management of WP Rocket plugin versions for E2E testing, eliminating the need for manual setup of plugin zip files. It adds a configuration-driven plugin manager that can automatically download, build, validate, and clean required plugin versions, along with CLI commands and documentation updates to support this workflow.

**Automated Plugin Version Management**

- Added a new plugin manager (`utils/plugin-manager.ts`) that automatically downloads or builds required WP Rocket plugin versions based on a configuration file, replacing the previous manual process. The manager supports fetching by version, GitHub branch/tag, or direct URL, and provides functions for setup, validation, listing, and cleaning plugin files.
- Introduced a CLI tool (`plugin-manager-cli.ts`) with commands to set up, list, clean, and validate plugin versions, integrated into npm scripts for easy use (`plugin:setup`, `plugin:list`, `plugin:clean`, `plugin:validate`). [[1]](diffhunk://#diff-bbbe3ed0d2233eb6623d86fb39ef52714bd8722648879e5f845d37d2e7afc867R1-R93) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R33-R42)

**Configuration and Documentation**

- Added a sample configuration file (`config/plugin.config.sample.ts`) for specifying which plugin versions to use, with support for version numbers, GitHub branches/tags, or URLs. Users copy and edit this file to control test versions.
- Updated `README.md` to document the new automated plugin management workflow, configuration steps, and available CLI commands, replacing the old manual instructions. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L7-R17) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R33-R36)

**Integration with Test Lifecycle**

- Updated test hooks (`src/support/hooks.ts`) to automatically validate and set up plugin versions before running tests, ensuring all required plugin files are present and up-to-date. [[1]](diffhunk://#diff-ed33bcf8419693abda7a86b9fc828c5e762fb6cd5101338898c04c91df14fb99R28) [[2]](diffhunk://#diff-ed33bcf8419693abda7a86b9fc828c5e762fb6cd5101338898c04c91df14fb99R69-R78)

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [ ] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification

No test for this