### PR TITLE
Exclude bwpup from e2e smoke instead of bwpupsmoke

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "lint": "eslint . --ext .ts",
     "lint:fix": "eslint  . --ext .ts --fix",
-    "test:e2e": "$npm_package_config_testCommand  --tags \"not @vr and not @delayjs and not @bwpupsmoke\" ; npm run push-report --tag=$npm_config_tag",
+    "test:e2e": "$npm_package_config_testCommand  --tags \"not @vr and not @delayjs and not @bwpup\" ; npm run push-report --tag=$npm_config_tag",
     "test:smoke": "$npm_package_config_testCommand --tags @smoke ; npm run push-report --tag=$npm_config_tag",
     "test:local": "$npm_package_config_testCommand --tags @local",
     "test:export": "$npm_package_config_testCommand --tags @export",


### PR DESCRIPTION
# Description
Exclude BWPU from e2e tests

Fixes failing e2e after adding bwpu CLI tests

## Type of change

- [ ] New feature (non-breaking change which adds functionality).
- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] Enhancement (non-breaking change which improves an existing functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as before).
- [ ] Sub-task of #(issue number)
- [ ] Chore
- [ ] Release

## Detailed scenario

### What was tested

Run e2e tests pass
<img width="1920" height="1080" alt="Screenshot from 2025-12-10 15-07-47" src="https://github.com/user-attachments/assets/bea57e5e-bc6e-4312-aa0d-580275844b5f" />


### How to test

As mentioned above

## Technical description

### Documentation

- Excludes bwpu instead of bwpusmoke which isnot there at CLI tests

### New dependencies

N/A

### Risks

N/A

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [ ] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [ ] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification

N/A
# Additional Checks
- [x] In the case of complex code, I wrote comments to explain it.
- [ ] When possible, I prepared ways to observe the implemented system (logs, data, etc.).
- [ ] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.)
