### PR TITLE
Fix 326 Check generated backup before passing test

### DIFF
--- a/src/backwpup/features/storages/ftp.feature
+++ b/src/backwpup/features/storages/ftp.feature
@@ -16,6 +16,7 @@ Feature: Should be able to work with FTP storage
     Then I save and submit the onboarding form
     And I go '/wp-admin/admin.php?page=backwpup'
     Then I should see 'mixed' job cards
+    And '1' backup is generated and added to history
 
   Scenario: Setup FTP from Dashboard (After Onboarding)
     When I Configure web server storage

--- a/src/backwpup/features/storages/glacier.feature
+++ b/src/backwpup/features/storages/glacier.feature
@@ -16,6 +16,7 @@ Feature: Should be able to work with Amazon Glacier storage
     Then I save and submit the onboarding form
     And I go '/wp-admin/admin.php?page=backwpup'
     Then I should see 'mixed' job cards
+    And '1' backup is generated and added to history
 
   Scenario: Setup Amazon Glacier from Dashboard (After Onboarding)
     When I Configure web server storage

--- a/src/backwpup/features/storages/rsc.feature
+++ b/src/backwpup/features/storages/rsc.feature
@@ -16,6 +16,7 @@ Feature: Should be able to work with Rackspace storage
     Then I save and submit the onboarding form
     And I go '/wp-admin/admin.php?page=backwpup'
     Then I should see 'mixed' job cards
+    And '1' backup is generated and added to history
 
   Scenario: Setup Rackspace from Dashboard (After Onboarding)
     When I Configure web server storage

--- a/src/backwpup/features/storages/s3.feature
+++ b/src/backwpup/features/storages/s3.feature
@@ -16,6 +16,7 @@ Feature: Should be able to work with S3 storage
     Then I save and submit the onboarding form
     And I go '/wp-admin/admin.php?page=backwpup'
     Then I should see 'mixed' job cards
+    And '1' backup is generated and added to history
 
   Scenario: Setup S3 from Dashboard (After Onboarding)
     When I Configure web server storage

--- a/src/backwpup/features/storages/sugarsync.feature
+++ b/src/backwpup/features/storages/sugarsync.feature
@@ -16,6 +16,7 @@ Feature: Should be able to work with SugarSync storage
     Then I save and submit the onboarding form
     And I go '/wp-admin/admin.php?page=backwpup'
     Then I should see 'mixed' job cards
+    And '1' backup is generated and added to history
 
   Scenario: Setup SugarSync from Dashboard (After Onboarding)
     When I Configure web server storage

--- a/src/backwpup/support/hooks.ts
+++ b/src/backwpup/support/hooks.ts
@@ -20,7 +20,7 @@ Before({tags: '@bwpupsetup'}, async function(this: ICustomWorld, {pickle}) {
     this.sections = new Sections(this.page, pluginSelectors);
     this.utils = new PageUtils(this.page, this.sections);
     this.storage = new StorageUtils(this.page, this.sections);
-
+    this.initialBackups = [];
     this.pickle = pickle;
 });
 


### PR DESCRIPTION
# Description

Fixes https://github.com/wp-media/wp-rocket-e2e/issues/326
This pull request makes improvements to the backup storage feature tests by ensuring that, after onboarding and initial storage setup, a backup is generated and recorded in the backup history for all supported storage types. Additionally, it initializes the `initialBackups` property in the test setup to ensure a clean state for each test scenario.

**Test scenario improvements:**

* Added a step to verify that a backup is generated and added to history after onboarding for the following storage types: FTP (`ftp.feature`), Amazon Glacier (`glacier.feature`), Rackspace (`rsc.feature`), S3 (`s3.feature`), and SugarSync (`sugarsync.feature`). [[1]](diffhunk://#diff-f321e83bc78760c61d1731cc2a73b2181410afa4f0972812f3d4e8194aaeb5f1R19) [[2]](diffhunk://#diff-ff36356e7baa73d67983e5548642113b4eb720c394e1ce5235334319331f2d39R19) [[3]](diffhunk://#diff-a881e630c8d3670a38fb057dfb361d81a7e13e83f875ad1f8ac4741cb28845a6R19) [[4]](diffhunk://#diff-cf1c4a07dfb8a2e6944ab45e14198aa83147c1a0f2909669ce3ca7e80c17e4ebR19) [[5]](diffhunk://#diff-4bbf0ed93374699ee99649bc15d6e9c1f72faf406d36a290a6a987bd23d94835R19)

**Test setup enhancements:**

* Initialized the `initialBackups` array in the `@bwpupsetup` test hook to ensure each test starts with a clean backup state (`hooks.ts`)

<img width="717" height="283" alt="image" src="https://github.com/user-attachments/assets/6cb47dfa-d80c-4815-bda7-d1e6f902dd7f" />

## Type of change

- [ ] New feature (non-breaking change which adds functionality).
- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] Enhancement (non-breaking change which improves an existing functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as before).
- [ ] Sub-task of #(issue number)
- [ ] Chore
- [ ] Release

## Detailed scenario

### What was tested

Ran all tests to make sure they are not affected. And ran all storage tests to make sure they are checking if the backup is really created after onboarding.

### How to test

`node ./node_modules/@cucumber/cucumber/bin/cucumber-js -p default --tags @bwpupstorage`

### Affected Features & Quality Assurance Scope

All storages tests.

## Technical description

### Documentation

Added a step to verify that a backup is generated and added to history after onboarding.

### New dependencies

N/A

### Risks

N/A

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification

N/A