### PR TITLE
fix: harden performance hints page restore checks

### DIFF
--- a/src/support/hooks.ts
+++ b/src/support/hooks.ts
@@ -216,7 +216,6 @@ Before({tags: '@vr'}, async function (this: ICustomWorld) {
 /**
  * Before each test scenario with the @performancehints tag, verifies required pages exist.
  */
-
 Before({tags: '@performancehints'}, async function (this: ICustomWorld) {
     const requiredPages = ['atf-lrc-1', 'atf-lrc-2'];
     

--- a/src/support/hooks.ts
+++ b/src/support/hooks.ts
@@ -19,10 +19,10 @@ import { ChromiumBrowser, chromium } from '@playwright/test';
 import { Sections } from '../common/sections';
 import { selectors as pluginSelectors } from "./../common/selectors";
 import { PageUtils } from "../../utils/page-utils";
-import { deleteFolder, isWprRelatedError } from "../../utils/helpers";
+import { deleteFolder, extractFromStdout, isWprRelatedError } from "../../utils/helpers";
 import {WP_SSH_ROOT_DIR,} from "../../config/wp.config";
 import { After, AfterAll, Before, BeforeAll, Status, setDefaultTimeout } from "@cucumber/cucumber";
-import {rename, exists, rm, testSshConnection, installRemotePlugin, activatePlugin, uninstallPlugin, readFile, isPluginActive, isPluginInstalled} from "../../utils/commands";
+import {rename, exists, rm, testSshConnection, installRemotePlugin, activatePlugin, uninstallPlugin, readFile, isPluginActive, isPluginInstalled, getPostDataFromTitle} from "../../utils/commands";
 import type { Selectors } from "../../utils/types";
 import type { Section } from "../../utils/types";
 // import {configurations, getWPDir} from "../../utils/configurations";
@@ -211,6 +211,26 @@ Before({tags: '@vr'}, async function (this: ICustomWorld) {
 
     this.wprSection = elementToParentMap[option] as Section;
     this.wprOption = option;
+});
+
+/**
+ * Before each test scenario with the @performancehints tag, verifies required pages exist.
+ */
+
+Before({tags: '@performancehints'}, async function (this: ICustomWorld) {
+    const requiredPages = ['atf-lrc-1', 'atf-lrc-2'];
+    
+    for (const pageName of requiredPages) {
+        const pageDataStdout = await getPostDataFromTitle(pageName, 'publish', 'ID,post_status');
+        const pageData = await extractFromStdout(pageDataStdout);
+        
+        if (!pageData || pageData.length === 0) {
+            throw new Error(
+                `Required test page '${pageName}' does not exist. ` +
+                `Template loader plugin may have failed.`
+            );
+        }
+    }
 });
 
 /**

--- a/src/support/steps/performance-hints.ts
+++ b/src/support/steps/performance-hints.ts
@@ -146,7 +146,6 @@ Then ('untrash and republish {string} page', async function (this: ICustomWorld,
     }
     
     await updatePostStatus(parseInt(postData[0].ID, 10), 'publish');
-    await this.page.waitForTimeout(2000); // Give WP time to process
     
     // Verify it actually worked
     const verifyStdout = await getPostDataFromTitle(permalink, 'publish', 'ID,post_status');

--- a/src/support/steps/performance-hints.ts
+++ b/src/support/steps/performance-hints.ts
@@ -140,5 +140,19 @@ When ('{string} page is deleted', async function (this: ICustomWorld, permalink:
 Then ('untrash and republish {string} page', async function (this: ICustomWorld, permalink: string) {
     const postDataStdout = await getPostDataFromTitle(permalink, 'trash', 'ID,post_title');
     const postData = await extractFromStdout(postDataStdout);
+    
+    if (!postData || postData.length === 0) {
+        throw new Error(`Failed to find page '${permalink}' in trash`);
+    }
+    
     await updatePostStatus(parseInt(postData[0].ID, 10), 'publish');
+    await this.page.waitForTimeout(2000); // Give WP time to process
+    
+    // Verify it actually worked
+    const verifyStdout = await getPostDataFromTitle(permalink, 'publish', 'ID,post_status');
+    const verifyData = await extractFromStdout(verifyStdout);
+    
+    if (!verifyData || verifyData.length === 0 || verifyData[0].post_status !== 'publish') {
+        throw new Error(`Failed to restore page '${permalink}' to published status`);
+    }
 });


### PR DESCRIPTION
# Description

Fixes #310 
Ensures required performance hints pages exist and adds explicit restore verification, preventing intermittent missing-page failures during E2E runs.

## Type of change

- [ ] New feature (non-breaking change which adds functionality).
- [x] Bug fix (non-breaking change which fixes an issue).
- [x] Enhancement (non-breaking change which improves an existing functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as before).
- [ ] Sub-task of #(issue number)
- [ ] Chore
- [ ] Release

## Detailed scenario

### What was tested

Automated: `npm run test:performancehints` x5 (to smoke out flakiness, all green).
<img width="862" height="406" alt="Screenshot 2026-01-15 at 11 28 01" src="https://github.com/user-attachments/assets/f8652f56-8d23-4e1c-a57f-03ff275d9e2c" />


### How to test

Run: `npm run test:performancehints`

### Affected Features & Quality Assurance Scope

- E2E performance hints tests.
- Page delete/restore flow for test pages atf-lrc-1 and atf-lrc-2.

## Technical description

### Documentation

Adds error handling and verification when restoring trashed test pages, and a pre-scenario guard that asserts required pages exist before @performancehints runs.

### New dependencies

None.

### Risks

None.

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [ ] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification

N/A

# Additional Checks
- [x] In the case of complex code, I wrote comments to explain it.
- [ ] When possible, I prepared ways to observe the implemented system (logs, data, etc.).
- [x] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.)
