### PR TITLE
fixed ftp test after backwpup FTP refactor (FTP, FTPS, SFTP and SFTPPK)

### DIFF
--- a/src/backwpup/utils/storage.ts
+++ b/src/backwpup/utils/storage.ts
@@ -128,10 +128,11 @@ export class StorageUtils {
         await this.page.locator('#ftpuser').fill(BACKWPUP_INFOS.ftp.username);
         await this.page.locator('#ftppass').fill(BACKWPUP_INFOS.ftp.password);
         await this.page.locator('#ftphostport').fill(BACKWPUP_INFOS.ftp.port ?? '21');
-        // Checkboxes
-        // Only set SSL checkbox if the SSL option checkbox element exists and is visible
-        const sslCheckboxVisible = await this.page.locator('#ftpssl').isVisible().catch(() => false);
-        if (sslCheckboxVisible) {
+        const ftpType = BACKWPUP_INFOS.ftp.ssl ? 'ftps' : 'ftp';
+        await this.page.locator('#ftpcontype').selectOption(ftpType);
+        // Only set passive mode checkbox if the passive mode option checkbox element exists and is visible
+        const passiveCheckboxVisible = await this.page.locator('#ftppasv').isVisible().catch(() => false);
+        if (passiveCheckboxVisible) {
         await this.page.locator('#ftppasv').setChecked(BACKWPUP_INFOS.ftp.passiveMode, { force: true });
         }
         const timestamp = Date.now();

--- a/src/backwpup/utils/storage.ts
+++ b/src/backwpup/utils/storage.ts
@@ -133,7 +133,7 @@ export class StorageUtils {
         // Only set passive mode checkbox if the passive mode option checkbox element exists and is visible
         const passiveCheckboxVisible = await this.page.locator('#ftppasv').isVisible().catch(() => false);
         if (passiveCheckboxVisible) {
-        await this.page.locator('#ftppasv').setChecked(BACKWPUP_INFOS.ftp.passiveMode, { force: true });
+            await this.page.locator('#ftppasv').setChecked(BACKWPUP_INFOS.ftp.passiveMode, { force: true });
         }
         const timestamp = Date.now();
         const directoryName = getFolderNameFromHost();


### PR DESCRIPTION
# Description

Fixes FTP tests after recent FTP module refactor in BackWPup (Brings back FTP and FTPS tests)

<img width="1027" height="396" alt="image" src="https://github.com/user-attachments/assets/69dcb0a8-d4c9-424b-9081-3e14abb335a4" />

## Type of change

- [ ] New feature (non-breaking change which adds functionality).
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] Enhancement (non-breaking change which improves an existing functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as before).
- [ ] Sub-task of #(issue number)
- [ ] Chore
- [ ] Release

## Detailed scenario

### What was tested

Retested FTP tests (only code changed in this project)

### How to test

Execute this:

`node ./node_modules/@cucumber/cucumber/bin/cucumber-js -p default --name 'Setup FTP'`

### Affected Features & Quality Assurance Scope

Only `setupFTP` function was changed

## Technical description

### Documentation

Managed FTP and FTPS in `setupFTP` function

### New dependencies

N/A

### Risks

N/A

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification

N/A