### PR TITLE
Fix CDN failed test due to new UI

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -21,7 +21,6 @@
         "src/common/deactivation.modal.ts",
         "src/common/safe.mode.disabled.options.check.ts",
         "src/common/safe.mode.disabled.options.ts",
-        "src/support/steps/steps.ts",
         "utils/commands.ts",
         "utils/configurations.ts"
       ]

--- a/src/features/cdn-banner.feature
+++ b/src/features/cdn-banner.feature
@@ -6,9 +6,9 @@ Feature: CDN banner
     And plugin is installed 'new_release'
     And plugin is activated
     And I am on the page '/wp-admin/options-general.php?page=wprocket#page_cdn'
-
+@test
   Scenario: Should validate that CDN purchase banner is displayed
-    Given I must see the banner 'High performance Content Delivery Network (CDN) with'
+    Given I must see the banner using selector '#wpr-rocketcdn-cta'
     And I click on '.wpr-rocketcdn-open'
     Then I must see the banner 'Login in to your WP Rocket Account to continue' in iframe '#rocketcdn-iframe'
 

--- a/src/features/cdn-banner.feature
+++ b/src/features/cdn-banner.feature
@@ -6,7 +6,7 @@ Feature: CDN banner
     And plugin is installed 'new_release'
     And plugin is activated
     And I am on the page '/wp-admin/options-general.php?page=wprocket#page_cdn'
-@test
+
   Scenario: Should validate that CDN purchase banner is displayed
     Given I must see the banner using selector '#wpr-rocketcdn-cta'
     And I click on '.wpr-rocketcdn-open'

--- a/src/support/steps/steps.ts
+++ b/src/support/steps/steps.ts
@@ -10,15 +10,14 @@
  * @requires {@link ../../../utils/configurations}
  */
 import {expect} from "@playwright/test";
-import wp, {
+import {
     activatePlugin,
     setTransient
 } from "../../../utils/commands";
 import { ICustomWorld } from "../../common/custom-world";
 import {configurations} from "../../../utils/configurations";
 import {match} from "ts-pattern";
-
-const { Given, When, Then } = require("@cucumber/cucumber");
+import { Given, When, Then } from "@cucumber/cucumber";
 
 /**
  * Executes the step to set up a WP account based on the provided status.
@@ -32,6 +31,7 @@ Given('I have an {word} account', { timeout: 60 * 1000 }, async function (this: 
         return
     }
 
+    /* eslint-disable @typescript-eslint/naming-convention */
     await setTransient('wp_rocket_customer_data', JSON.stringify({
         'ID' : 1,
         'firstname' : 'Rocket',
@@ -51,6 +51,7 @@ Given('I have an {word} account', { timeout: 60 * 1000 }, async function (this: 
         'upgrade_infinite_url' : 'https://example.org/upgrade_infinite_url'
     }).replaceAll('"', '\\"')
         .replaceAll('}', '\\}'))
+    /* eslint-enable @typescript-eslint/naming-convention */
 
     await this.page.reload();
 });
@@ -162,7 +163,7 @@ When('I go {string}', async function (this: ICustomWorld, url: string) {
 /**
  * Executes the step to connect as a specific user.
  */
-When('I connect as {string}', async function (this: ICustomWorld, user: string) {
+When('I connect as {string}', async function (this: ICustomWorld) {
    await this.utils.wpAdminLogout();
     await this.utils.auth('admin2');
 });

--- a/src/support/steps/steps.ts
+++ b/src/support/steps/steps.ts
@@ -163,9 +163,9 @@ When('I go {string}', async function (this: ICustomWorld, url: string) {
 /**
  * Executes the step to connect as a specific user.
  */
-When('I connect as {string}', async function (this: ICustomWorld) {
+When('I connect as {string}', async function (this: ICustomWorld, user: string) {
    await this.utils.wpAdminLogout();
-    await this.utils.auth('admin2');
+    await this.utils.auth(user);
 });
 
 /**

--- a/src/support/steps/steps.ts
+++ b/src/support/steps/steps.ts
@@ -74,7 +74,7 @@ Then('I must see the banner {string}', async function (this: ICustomWorld, text:
  * Executes the step to assert the visibility of a banner with specific selector.
  */
 Then('I must see the banner using selector {string}', async function (this: ICustomWorld, selector: string) {
-  await expect(this.page.locator(selector)).toBeVisible({ timeout: 15000 });
+    await expect(this.page.locator(selector)).toBeVisible({ timeout: 15000 });
 });
 
 

--- a/src/support/steps/steps.ts
+++ b/src/support/steps/steps.ts
@@ -70,6 +70,14 @@ Then('I must see the banner {string}', async function (this: ICustomWorld, text:
 });
 
 /**
+ * Executes the step to assert the visibility of a banner with specific selector.
+ */
+Then('I must see the banner using selector {string}', async function (this: ICustomWorld, selector: string) {
+  await expect(this.page.locator(selector)).toBeVisible({ timeout: 15000 });
+});
+
+
+/**
  * Executes the step to assert the visibility of a banner in iframe with specific text.
  */
 Then('I must see the banner {string} in iframe {string}', async function (this: ICustomWorld, text: string, iframeSelector: string) {


### PR DESCRIPTION
# Description
e2e test `Should validate that CDN purchase banner is displayed` lately failed due to an update in CDN banner text 

## Type of change

- [ ] New feature (non-breaking change which adds functionality).
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] Enhancement (non-breaking change which improves an existing functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as before).
- [ ] Sub-task of #(issue number)
- [ ] Chore
- [ ] Release

## Detailed scenario

### What was tested
- Run CDN failed test on 3.20.6, 3.20.5 pass
- Ruc CDN test on 3.20.0.2 fail

### How to test

- Same as above
- Run all e2e , should be green

### Affected Features & Quality Assurance Scope
- CDN test

## Technical description

### Documentation

- Instead of asserting  CDN banner by text, assertion now by id
- step could be reused later

### New dependencies

N/A
### Risks

N/A
# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [ ] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [ ] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [ ] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification

N/A
# Additional Checks
- [x] In the case of complex code, I wrote comments to explain it.
- [ ] When possible, I prepared ways to observe the implemented system (logs, data, etc.).
- [ ] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.)
