### PR TITLE
Add Query Monitor checks for WPR activation errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "test:performancehints": "$npm_package_config_testCommand --tags @performancehints",
     "test:cloudflare-compatibility": "$npm_package_config_testCommand --tags @cloudflare-compatibility",
     "test:brokenlinks": "$npm_package_config_testCommand --tags @brokenlinks",
+    "test:qm": "$npm_package_config_testCommand --tags @qm",
     "healthcheck": "ts-node healthcheck.ts",
     "push-report": "ts-node report.ts",
     "wp-env": "wp-env",

--- a/src/features/query-monitor-no-errors.feature
+++ b/src/features/query-monitor-no-errors.feature
@@ -5,7 +5,7 @@ Feature: C16919 - Should have no error in query monitor when activating WPR
     Given I am logged in
 
   Scenario: Activate WP Rocket on latest WordPress
-    Given WP is latest WP
+    Given WordPress core is up to date
     And Query monitor is active
     When plugin is installed 'new_release'
     And plugin is activated

--- a/src/features/query-monitor-no-errors.feature
+++ b/src/features/query-monitor-no-errors.feature
@@ -1,0 +1,13 @@
+@setup @smoke @qm
+Feature: C16919 - Should have no error in query monitor when activating WPR
+
+  Background:
+    Given I am logged in
+
+  Scenario: Activate WP Rocket on latest WordPress
+    Given WP is latest WP
+    And Query monitor is active
+    When plugin is installed 'new_release'
+    And plugin is activated
+    Then no PHP error in query monitor about WPR
+    And no doing it wrong for WPR

--- a/src/features/query-monitor-no-errors.feature
+++ b/src/features/query-monitor-no-errors.feature
@@ -9,5 +9,4 @@ Feature: C16919 - Should have no error in query monitor when activating WPR
     And Query monitor is active
     When plugin is installed 'new_release'
     And plugin is activated
-    Then no PHP error in query monitor about WPR
-    And no doing it wrong for WPR
+    Then Query monitor shows no WP Rocket errors or warnings

--- a/src/support/hooks.ts
+++ b/src/support/hooks.ts
@@ -297,7 +297,7 @@ After({tags: '@cloudflare-compatibility'}, async function (this: ICustomWorld) {
     }
 });
 
-After({tags: '@qm'}, async function (this: ICustomWorld) {
+After({tags: '@qm'}, async function (this: ICustomWorld): Promise<void>  {
     if (await isPluginInstalled('query-monitor')) {
         await uninstallPlugin('query-monitor');
     }

--- a/src/support/hooks.ts
+++ b/src/support/hooks.ts
@@ -297,6 +297,12 @@ After({tags: '@cloudflare-compatibility'}, async function (this: ICustomWorld) {
     }
 });
 
+After({tags: '@qm'}, async function (this: ICustomWorld) {
+    if (await isPluginInstalled('query-monitor')) {
+        await uninstallPlugin('query-monitor');
+    }
+});
+
 /**
  * To uncomment during implementation of cli
  */

--- a/src/support/steps/general.ts
+++ b/src/support/steps/general.ts
@@ -179,7 +179,7 @@ Given('I install plugin {string}', async function (pluginUrl) {
 /**
  * Ensures WordPress core is on the latest version
  */
-Given('WP is latest WP', async function (this: ICustomWorld): Promise<void>  {
+Given('WordPress core is up to date', async function (this: ICustomWorld): Promise<void>  {
     const result = await wpWithOutput('core check-update --format=csv --fields=version');
 
     if (result.failed) {

--- a/src/support/steps/general.ts
+++ b/src/support/steps/general.ts
@@ -20,7 +20,7 @@ import { compareReference, isTagPresent, getScenarioTag, batchUpdateVRTestUrl} f
 import type { Section } from "../../../utils/types";
 import { Page } from '@playwright/test';
 import {
-    deactivatePlugin, installRemotePlugin,
+    deactivatePlugin, installRemotePlugin, wpWithOutput,
 } from "../../../utils/commands";
 import backstop from 'backstopjs';
 
@@ -176,6 +176,31 @@ Given('I install plugin {string}', async function (pluginUrl) {
     await installRemotePlugin(pluginUrl)
 });
 
+/**
+ * Ensures WordPress core is on the latest version
+ */
+Given('WP is latest WP', async function (this: ICustomWorld): Promise<void>  {
+    const result = await wpWithOutput('core check-update --format=csv --fields=version');
+
+    if (result.failed) {
+        throw new Error(
+            `Failed to verify WordPress core version via "wp core check-update".` +
+            `\nSTDOUT:\n${result.stdout}\nSTDERR:\n${result.stderr}`
+        );
+    }
+
+    const lines = (result.stdout ?? '').trim().split('\n').filter(line => line.trim() !== '');
+    // When up to date, only the CSV header line is returned — no data rows.
+    const hasUpdates = lines.length > 1;
+
+    if (hasUpdates) {
+        throw new Error(
+            `WordPress core is not on the latest version.` +
+            `\n"wp core check-update" reported available updates.` +
+            `\nSTDOUT:\n${result.stdout}\nSTDERR:\n${result.stderr}`
+        );
+    }
+});
 
 /**
  * Executes the step to visit a specific page.

--- a/src/support/steps/query-monitor.ts
+++ b/src/support/steps/query-monitor.ts
@@ -21,12 +21,29 @@ import {
  */
 Given('WP is latest WP', async function (this: ICustomWorld) {
     const result = await wpWithOutput('core update');
-    // Acceptable outcomes: already at latest, or successfully updated
-    const success = !result.failed 
-        || result.stdout.includes('WordPress is up to date')
-        || result.stdout.includes('Success');
-    if (!success) {
-        throw new Error(`Failed to update WordPress core: ${result.stderr}`);
+
+    if (result.failed) {
+        throw new Error(
+            `Failed to update WordPress core.\nSTDOUT:\n${result.stdout}\nSTDERR:\n${result.stderr}`
+        );
+    }
+
+    const stdout = result.stdout ?? '';
+    const isAlreadyUpToDate = stdout.includes('WordPress is up to date');
+    const isUpdateSuccess = stdout.includes('Success');
+
+    if (!isAlreadyUpToDate && !isUpdateSuccess) {
+        throw new Error(
+            `Unexpected output from "wp core update".\nSTDOUT:\n${stdout}\nSTDERR:\n${result.stderr}`
+        );
+    }
+
+    const updateDbResult = await wpWithOutput('core update-db');
+
+    if (updateDbResult.failed) {
+        throw new Error(
+            `Failed to run "wp core update-db".\nSTDOUT:\n${updateDbResult.stdout}\nSTDERR:\n${updateDbResult.stderr}`
+        );
     }
 });
 

--- a/src/support/steps/query-monitor.ts
+++ b/src/support/steps/query-monitor.ts
@@ -11,7 +11,6 @@ import { Given, Then } from '@cucumber/cucumber';
 import { ICustomWorld } from '../../common/custom-world';
 import {
     activatePlugin,
-    installRemotePlugin,
     isPluginInstalled,
     wpWithOutput,
 } from '../../../utils/commands';

--- a/src/support/steps/query-monitor.ts
+++ b/src/support/steps/query-monitor.ts
@@ -16,32 +16,6 @@ import {
 } from '../../../utils/commands';
 
 /**
- * Ensures WordPress core is on the latest version
- */
-Given('WP is latest WP', async function (this: ICustomWorld): Promise<void>  {
-    const result = await wpWithOutput('core check-update --format=csv --fields=version');
-
-    if (result.failed) {
-        throw new Error(
-            `Failed to verify WordPress core version via "wp core check-update".` +
-            `\nSTDOUT:\n${result.stdout}\nSTDERR:\n${result.stderr}`
-        );
-    }
-
-    const lines = (result.stdout ?? '').trim().split('\n').filter(line => line.trim() !== '');
-    // When up to date, only the CSV header line is returned — no data rows.
-    const hasUpdates = lines.length > 1;
-
-    if (hasUpdates) {
-        throw new Error(
-            `WordPress core is not on the latest version.` +
-            `\n"wp core check-update" reported available updates.` +
-            `\nSTDOUT:\n${result.stdout}\nSTDERR:\n${result.stderr}`
-        );
-    }
-});
-
-/**
  * Ensures Query Monitor plugin is installed and active
  */
 Given('Query monitor is active', async function (this: ICustomWorld): Promise<void>  {

--- a/src/support/steps/query-monitor.ts
+++ b/src/support/steps/query-monitor.ts
@@ -19,30 +19,25 @@ import {
 /**
  * Ensures WordPress core is on the latest version
  */
-Given('WP is latest WP', async function (this: ICustomWorld) {
-    const result = await wpWithOutput('core update');
+Given('WP is latest WP', async function (this: ICustomWorld): Promise<void>  {
+    const result = await wpWithOutput('core check-update --format=csv --fields=version');
 
     if (result.failed) {
         throw new Error(
-            `Failed to update WordPress core.\nSTDOUT:\n${result.stdout}\nSTDERR:\n${result.stderr}`
+            `Failed to verify WordPress core version via "wp core check-update".` +
+            `\nSTDOUT:\n${result.stdout}\nSTDERR:\n${result.stderr}`
         );
     }
 
-    const stdout = result.stdout ?? '';
-    const isAlreadyUpToDate = stdout.includes('WordPress is up to date');
-    const isUpdateSuccess = stdout.includes('Success');
+    const lines = (result.stdout ?? '').trim().split('\n').filter(line => line.trim() !== '');
+    // When up to date, only the CSV header line is returned — no data rows.
+    const hasUpdates = lines.length > 1;
 
-    if (!isAlreadyUpToDate && !isUpdateSuccess) {
+    if (hasUpdates) {
         throw new Error(
-            `Unexpected output from "wp core update".\nSTDOUT:\n${stdout}\nSTDERR:\n${result.stderr}`
-        );
-    }
-
-    const updateDbResult = await wpWithOutput('core update-db');
-
-    if (updateDbResult.failed) {
-        throw new Error(
-            `Failed to run "wp core update-db".\nSTDOUT:\n${updateDbResult.stdout}\nSTDERR:\n${updateDbResult.stderr}`
+            `WordPress core is not on the latest version.` +
+            `\n"wp core check-update" reported available updates.` +
+            `\nSTDOUT:\n${result.stdout}\nSTDERR:\n${result.stderr}`
         );
     }
 });
@@ -50,7 +45,7 @@ Given('WP is latest WP', async function (this: ICustomWorld) {
 /**
  * Ensures Query Monitor plugin is installed and active
  */
-Given('Query monitor is active', async function (this: ICustomWorld) {
+Given('Query monitor is active', async function (this: ICustomWorld): Promise<void>  {
     const isInstalled = await isPluginInstalled('query-monitor');
     if (!isInstalled) {
         await installRemotePlugin('https://downloads.wordpress.org/plugin/query-monitor.latest-stable.zip');
@@ -80,7 +75,7 @@ const openQueryMonitorToolbar = async function (this: ICustomWorld): Promise<voi
 /**
  * Verifies Query Monitor has no WP Rocket related entries in the PHP errors panel
  */
-Then('no PHP error in query monitor about WPR', async function (this: ICustomWorld) {
+Then('no PHP error in query monitor about WPR', async function (this: ICustomWorld): Promise<void>  {
     await openQueryMonitorToolbar.call(this);
 
     // QM renders a hidden panel; expand it to make it accessible to Playwright
@@ -102,7 +97,7 @@ Then('no PHP error in query monitor about WPR', async function (this: ICustomWor
 /**
  * Verifies Query Monitor has no WP Rocket related entries in the doing_it_wrong panel
  */
-Then('no doing it wrong for WPR', async function (this: ICustomWorld) {
+Then('no doing it wrong for WPR', async function (this: ICustomWorld): Promise<void>  {
     await openQueryMonitorToolbar.call(this);
 
     const qmPanel = this.page.locator('#qm-doing_it_wrong');

--- a/src/support/steps/query-monitor.ts
+++ b/src/support/steps/query-monitor.ts
@@ -1,0 +1,104 @@
+/**
+ * @fileoverview
+ * This module contains Query Monitor compatibility step definitions for WP Rocket activation.
+ *
+ * @requires {@link ../../common/custom-world}
+ * @requires {@link @cucumber/cucumber}
+ * @requires {@link @playwright/test}
+ * @requires {@link ../../../utils/commands}
+ */
+import { Given, Then } from '@cucumber/cucumber';
+import { ICustomWorld } from '../../common/custom-world';
+import {
+    activatePlugin,
+    installRemotePlugin,
+    isPluginInstalled,
+    wpWithOutput,
+} from '../../../utils/commands';
+
+/**
+ * Ensures WordPress core is on the latest version
+ */
+Given('WP is latest WP', async function (this: ICustomWorld) {
+    const result = await wpWithOutput('core update');
+    // Acceptable outcomes: already at latest, or successfully updated
+    const success = !result.failed 
+        || result.stdout.includes('WordPress is up to date')
+        || result.stdout.includes('Success');
+    if (!success) {
+        throw new Error(`Failed to update WordPress core: ${result.stderr}`);
+    }
+});
+
+/**
+ * Ensures Query Monitor plugin is installed and active
+ */
+Given('Query monitor is active', async function (this: ICustomWorld) {
+    const isInstalled = await isPluginInstalled('query-monitor');
+    if (!isInstalled) {
+        await installRemotePlugin('https://downloads.wordpress.org/plugin/query-monitor.latest-stable.zip');
+    }
+    await activatePlugin('query-monitor');
+});
+
+/**
+ * Opens Query Monitor toolbar panel in wp-admin
+ *
+ * @return {Promise<void>}
+ */
+const openQueryMonitorToolbar = async function (this: ICustomWorld): Promise<void> {
+    await this.utils.gotoWpr();
+    await this.page.waitForLoadState('load', { timeout: 30000 });
+
+    const qmToolbar = this.page.locator('#wp-admin-bar-query-monitor');
+    await qmToolbar.waitFor({ state: 'visible', timeout: 10000 });
+
+    await qmToolbar.locator('a.ab-item').first().click();
+
+    // Wait for QM to render its panel container in the DOM (may remain visually hidden)
+    const qmMain = this.page.locator('#query-monitor-main');
+    await qmMain.waitFor({ state: 'attached', timeout: 10000 });
+};
+
+/**
+ * Verifies Query Monitor has no WP Rocket related entries in the PHP errors panel
+ */
+Then('no PHP error in query monitor about WPR', async function (this: ICustomWorld) {
+    await openQueryMonitorToolbar.call(this);
+
+    // QM renders a hidden panel; expand it to make it accessible to Playwright
+    const qmPanel = this.page.locator('#qm-php_errors');
+    const panelExists = await qmPanel.count() > 0;
+    if (!panelExists) {
+        return; // No PHP errors panel = no errors
+    }
+
+    const errorText = await qmPanel.textContent();
+    const wprRelated = errorText?.includes('/plugins/wp-rocket/') 
+        || errorText?.includes('WP_Rocket');
+
+    if (wprRelated) {
+        throw new Error(`PHP errors from WP Rocket found in Query Monitor:\n${errorText}`);
+    }
+});
+
+/**
+ * Verifies Query Monitor has no WP Rocket related entries in the doing_it_wrong panel
+ */
+Then('no doing it wrong for WPR', async function (this: ICustomWorld) {
+    await openQueryMonitorToolbar.call(this);
+
+    const qmPanel = this.page.locator('#qm-doing_it_wrong');
+    const panelExists = await qmPanel.count() > 0;
+    if (!panelExists) {
+        return; // No doing_it_wrong panel = no notices
+    }
+
+    const noticeText = await qmPanel.textContent();
+    const wprRelated = noticeText?.includes('/plugins/wp-rocket/') 
+        || noticeText?.includes('WP_Rocket');
+
+    if (wprRelated) {
+        throw new Error(`doing_it_wrong notices from WP Rocket found in Query Monitor:\n${noticeText}`);
+    }
+});

--- a/src/support/steps/query-monitor.ts
+++ b/src/support/steps/query-monitor.ts
@@ -48,7 +48,13 @@ Given('WP is latest WP', async function (this: ICustomWorld): Promise<void>  {
 Given('Query monitor is active', async function (this: ICustomWorld): Promise<void>  {
     const isInstalled = await isPluginInstalled('query-monitor');
     if (!isInstalled) {
-        await installRemotePlugin('https://downloads.wordpress.org/plugin/query-monitor.latest-stable.zip');
+        const result = await wpWithOutput('plugin install query-monitor');
+        if (result.failed) {
+            throw new Error(
+                `Failed to install Query Monitor via "wp plugin install query-monitor".` +
+                `\nSTDOUT:\n${result.stdout}\nSTDERR:\n${result.stderr}`
+            );
+        }
     }
     await activatePlugin('query-monitor');
 });
@@ -73,44 +79,38 @@ const openQueryMonitorToolbar = async function (this: ICustomWorld): Promise<voi
 };
 
 /**
- * Verifies Query Monitor has no WP Rocket related entries in the PHP errors panel
+ * Verifies Query Monitor shows no WP Rocket errors or warnings
  */
-Then('no PHP error in query monitor about WPR', async function (this: ICustomWorld): Promise<void>  {
+Then('Query monitor shows no WP Rocket errors or warnings', async function (this: ICustomWorld): Promise<void>  {
     await openQueryMonitorToolbar.call(this);
 
-    // QM renders a hidden panel; expand it to make it accessible to Playwright
-    const qmPanel = this.page.locator('#qm-php_errors');
-    const panelExists = await qmPanel.count() > 0;
-    if (!panelExists) {
-        return; // No PHP errors panel = no errors
+    const issues: string[] = [];
+
+    // Check PHP errors panel
+    const phpErrorPanel = this.page.locator('#qm-php_errors');
+    const phpErrorExists = await phpErrorPanel.count() > 0;
+    if (phpErrorExists) {
+        const errorText = await phpErrorPanel.textContent();
+        const wprRelated = (errorText?.includes('/plugins/wp-rocket/') 
+            || errorText?.includes('WP_Rocket'))
+        if (wprRelated) {
+            issues.push(`PHP errors from WP Rocket:\n${errorText}`);
+        }
     }
 
-    const errorText = await qmPanel.textContent();
-    const wprRelated = errorText?.includes('/plugins/wp-rocket/') 
-        || errorText?.includes('WP_Rocket');
-
-    if (wprRelated) {
-        throw new Error(`PHP errors from WP Rocket found in Query Monitor:\n${errorText}`);
-    }
-});
-
-/**
- * Verifies Query Monitor has no WP Rocket related entries in the doing_it_wrong panel
- */
-Then('no doing it wrong for WPR', async function (this: ICustomWorld): Promise<void>  {
-    await openQueryMonitorToolbar.call(this);
-
-    const qmPanel = this.page.locator('#qm-doing_it_wrong');
-    const panelExists = await qmPanel.count() > 0;
-    if (!panelExists) {
-        return; // No doing_it_wrong panel = no notices
+    // Check doing_it_wrong panel
+    const doingWrongPanel = this.page.locator('#qm-doing_it_wrong');
+    const doingWrongExists = await doingWrongPanel.count() > 0;
+    if (doingWrongExists) {
+        const noticeText = await doingWrongPanel.textContent();
+        const wprRelated = noticeText?.includes('/plugins/wp-rocket/') 
+            || noticeText?.includes('WP_Rocket');
+        if (wprRelated) {
+            issues.push(`doing_it_wrong notices from WP Rocket:\n${noticeText}`);
+        }
     }
 
-    const noticeText = await qmPanel.textContent();
-    const wprRelated = noticeText?.includes('/plugins/wp-rocket/') 
-        || noticeText?.includes('WP_Rocket');
-
-    if (wprRelated) {
-        throw new Error(`doing_it_wrong notices from WP Rocket found in Query Monitor:\n${noticeText}`);
+    if (issues.length > 0) {
+        throw new Error(`Query Monitor detected WP Rocket issues:\n\n${issues.join('\n\n')}`);
     }
 });


### PR DESCRIPTION
# Description

This PR adds a new scenario to check that WPR with latest WP version does not trigger doing-it-wrong notices or PHP errors in Query Monitor. 

Fixes #204 

## Type of change

- [x] New feature (non-breaking change which adds functionality).
- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] Enhancement (non-breaking change which improves an existing functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as before).
- [ ] Sub-task of #(issue number)
- [ ] Chore
- [ ] Release

## Detailed scenario

### What was tested

- Ran smoke tests and the dedicated Query Monitor scenario with tag `@qm`.

Negative validation with new_release = 3.17.2.1: this version is known to trigger doing_it_wrong notices. The scenario failed as expected.
<img width="1627" height="1117" alt="doing_it_wrong" src="https://github.com/user-attachments/assets/bb7efd7a-457c-4119-a191-256a4f9aa393" />
Negative validation with new_release = 3.18.1: this version is known to trigger PHP errors. The scenario failed as expected.
<img width="1616" height="1263" alt="PHP_errors" src="https://github.com/user-attachments/assets/cd1750ab-2fd6-4e55-bf42-6fdfed47b7e3" />
Positive validation with a clean WP Rocket version, e.g. 3.21: scenario passed with no Query Monitor PHP errors and no doing_it_wrong notices.

### How to test

As mentioned above

### Affected Features & Quality Assurance Scope

Query Monitor test.

## Technical description

### Documentation

Implementation adds:

- New feature scenario for Query Monitor error verification on activation
- New step definitions:
   - Ensure WP is latest
   - Ensure Query Monitor is installed/active
   - Open Query Monitor from admin toolbar
   - Assert absence of WP Rocket related entries in:
      - PHP errors panel
      - doing-it-wrong panel
- `@qm` hook cleanup to uninstall Query Monitor after scenario

### New dependencies

None

### Risks

- Selector fragility if Query Monitor UI markup changes
   Mitigation: selectors were validated on the target environment.
- Potential test state pollution from plugin install
   Mitigation: `@qm` teardown uninstalls Query Monitor.

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification

N/A

# Additional Checks
- [x] In the case of complex code, I wrote comments to explain it.
- [x] When possible, I prepared ways to observe the implemented system (logs, data, etc.).
- [ ] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.)
