### PR TITLE
fix: allow WP prerelease builds in core version gate

### DIFF
--- a/src/support/steps/general.ts
+++ b/src/support/steps/general.ts
@@ -24,12 +24,6 @@ import {
 } from "../../../utils/commands";
 import backstop from 'backstopjs';
 
-type CoreUpdate = {
-    version?: string;
-};
-
-const isStableWpVersion = (version: string): boolean => /^\d+(?:\.\d+){1,2}$/.test(version);
-
 /**
  * Executes the step to log in.
  */
@@ -205,93 +199,35 @@ Given('I install plugin {string}', async function (pluginUrl) {
 /**
  * Ensures WordPress core is latest stable or newer.
  * Fails only when current version is lower than latest stable.
+ * Allows prerelease/dev builds (RC, beta, dev) as long as they're >= latest stable numeric release.
  */
-Given('WordPress core is up to date', async function (this: ICustomWorld): Promise<void> {
-    const updatesResult = await wpWithOutput('core check-update --format=json --fields=version');
+Given('WordPress core is up to date', async function (): Promise<void> {
+    const current = (await wpWithOutput('core version')).stdout.trim();
 
-    if (updatesResult.failed) {
-        throw new Error(
-            `Failed to verify WordPress core version via "wp core check-update".` +
-            `\nSTDOUT:\n${updatesResult.stdout}\nSTDERR:\n${updatesResult.stderr}`
-        );
-    }
+    const latestStable = (await wpWithOutput(
+        "core check-update --field=version"
+    )).stdout
+        .split('\n')
+        .map(v => v.trim())
+        .filter(v => v && !v.includes('-')) // only stable (no RC, beta, dev suffixes)
+        .sort((a, b) => a.localeCompare(b, undefined, { numeric: true }))
+        .pop();
 
-    const rawUpdates = (updatesResult.stdout ?? '').trim();
-    let updates: CoreUpdate[] = [];
+    // If no stable updates → already latest or newer (RC/dev)
+    if (!latestStable) return;
 
-    if (rawUpdates.length > 0) {
-        try {
-            const parsed: unknown = JSON.parse(rawUpdates);
-            updates = Array.isArray(parsed) ? (parsed as CoreUpdate[]) : [];
-        } catch {
-            throw new Error(
-                `Unable to parse "wp core check-update" JSON output.` +
-                `\nSTDOUT:\n${updatesResult.stdout}\nSTDERR:\n${updatesResult.stderr}`
-            );
-        }
-    }
-
-    const stableUpdates = updates
-        .map((update: CoreUpdate) => (update.version ?? '').trim())
-        .filter((version: string) => version.length > 0)
-        .filter((version: string) => isStableWpVersion(version));
-
-    // No stable updates available => already latest stable or newer.
-    // This allows prerelease/dev builds like 7.0-RC1-62113 to pass.
-    if (stableUpdates.length === 0) {
-        return;
-    }
-
-    const latestStable = stableUpdates
-        .sort((a: string, b: string) => a.localeCompare(b, undefined, { numeric: true, sensitivity: 'base' }))
-        .at(-1);
-
-    if (!latestStable) {
-        return;
-    }
-
-    const currentResult = await wpWithOutput('core version');
-
-    if (currentResult.failed) {
-        throw new Error(
-            `Failed to read current WordPress version via "wp core version".` +
-            `\nSTDOUT:\n${currentResult.stdout}\nSTDERR:\n${currentResult.stderr}`
-        );
-    }
-
-    const currentVersion = (currentResult.stdout ?? '').trim();
-
-    if (currentVersion.length === 0) {
-        throw new Error(
-            `Current WordPress version is empty.` +
-            `\nSTDOUT:\n${currentResult.stdout}\nSTDERR:\n${currentResult.stderr}`
-        );
-    }
-
-    const safeCurrent = currentVersion.replace(/'/g, "\\'");
-    const safeLatest = latestStable.replace(/'/g, "\\'");
-
-    const comparisonResult = await wpWithOutput(
-        `eval "echo version_compare('${safeCurrent}', '${safeLatest}', '>=') ? '1' : '0';"`
+    const compare = await wpWithOutput(
+        `eval "echo version_compare('${current.replace(/'/g, "\\'")}'` +
+        `, '${latestStable.replace(/'/g, "\\'")}'` +
+        `, '>=') ? '1' : '0';"`
     );
 
-    if (comparisonResult.failed) {
-        throw new Error(
-            `Failed to compare WordPress core version against latest stable.` +
-            `\nCurrent: ${currentVersion}` +
-            `\nLatest stable: ${latestStable}` +
-            `\nComparison STDOUT:\n${comparisonResult.stdout}\nComparison STDERR:\n${comparisonResult.stderr}` +
-            `\nCheck-update STDOUT:\n${updatesResult.stdout}\nCheck-update STDERR:\n${updatesResult.stderr}`
-        );
-    }
-
-    if ((comparisonResult.stdout ?? '').trim() !== '1') {
+    if (compare.stdout.trim() !== '1') {
         throw new Error(
             `WordPress core is below the latest stable version.` +
-            `\nCurrent: ${currentVersion}` +
-            `\nLatest stable: ${latestStable}` +
-            `\nComparison STDOUT:\n${comparisonResult.stdout}\nComparison STDERR:\n${comparisonResult.stderr}` +
-            `\nCheck-update STDOUT:\n${updatesResult.stdout}\nCheck-update STDERR:\n${updatesResult.stderr}`
+            `\nCurrent: ${current}\nLatest stable: ${latestStable}` +
+            `\nComparison STDOUT:\n${compare.stdout}` +
+            `\nComparison STDERR:\n${compare.stderr}`
         );
     }
 });

--- a/src/support/steps/general.ts
+++ b/src/support/steps/general.ts
@@ -24,6 +24,12 @@ import {
 } from "../../../utils/commands";
 import backstop from 'backstopjs';
 
+type CoreUpdate = {
+    version?: string;
+};
+
+const isStableWpVersion = (version: string): boolean => /^\d+(?:\.\d+){1,2}$/.test(version);
+
 /**
  * Executes the step to log in.
  */
@@ -197,27 +203,84 @@ Given('I install plugin {string}', async function (pluginUrl) {
 });
 
 /**
- * Ensures WordPress core is on the latest version
+ * Ensures WordPress core is latest stable or newer.
+ * Fails only when current version is lower than latest stable.
  */
-Given('WordPress core is up to date', async function (this: ICustomWorld): Promise<void>  {
-    const result = await wpWithOutput('core check-update --format=csv --fields=version');
+Given('WordPress core is up to date', async function (this: ICustomWorld): Promise<void> {
+    const updatesResult = await wpWithOutput('core check-update --format=json --fields=version');
 
-    if (result.failed) {
+    if (updatesResult.failed) {
         throw new Error(
             `Failed to verify WordPress core version via "wp core check-update".` +
-            `\nSTDOUT:\n${result.stdout}\nSTDERR:\n${result.stderr}`
+            `\nSTDOUT:\n${updatesResult.stdout}\nSTDERR:\n${updatesResult.stderr}`
         );
     }
 
-    const lines = (result.stdout ?? '').trim().split('\n').filter(line => line.trim() !== '');
-    // When up to date, only the CSV header line is returned — no data rows.
-    const hasUpdates = lines.length > 1;
+    const rawUpdates = (updatesResult.stdout ?? '').trim();
+    let updates: CoreUpdate[] = [];
 
-    if (hasUpdates) {
+    if (rawUpdates.length > 0) {
+        try {
+            const parsed: unknown = JSON.parse(rawUpdates);
+            updates = Array.isArray(parsed) ? (parsed as CoreUpdate[]) : [];
+        } catch {
+            throw new Error(
+                `Unable to parse "wp core check-update" JSON output.` +
+                `\nSTDOUT:\n${updatesResult.stdout}\nSTDERR:\n${updatesResult.stderr}`
+            );
+        }
+    }
+
+    const stableUpdates = updates
+        .map((update: CoreUpdate) => (update.version ?? '').trim())
+        .filter((version: string) => version.length > 0)
+        .filter((version: string) => isStableWpVersion(version));
+
+    // No stable updates available => already latest stable or newer.
+    // This allows prerelease/dev builds like 7.0-RC1-62113 to pass.
+    if (stableUpdates.length === 0) {
+        return;
+    }
+
+    const latestStable = stableUpdates
+        .sort((a: string, b: string) => a.localeCompare(b, undefined, { numeric: true, sensitivity: 'base' }))
+        .at(-1);
+
+    if (!latestStable) {
+        return;
+    }
+
+    const currentResult = await wpWithOutput('core version');
+
+    if (currentResult.failed) {
         throw new Error(
-            `WordPress core is not on the latest version.` +
-            `\n"wp core check-update" reported available updates.` +
-            `\nSTDOUT:\n${result.stdout}\nSTDERR:\n${result.stderr}`
+            `Failed to read current WordPress version via "wp core version".` +
+            `\nSTDOUT:\n${currentResult.stdout}\nSTDERR:\n${currentResult.stderr}`
+        );
+    }
+
+    const currentVersion = (currentResult.stdout ?? '').trim();
+
+    if (currentVersion.length === 0) {
+        throw new Error(
+            `Current WordPress version is empty.` +
+            `\nSTDOUT:\n${currentResult.stdout}\nSTDERR:\n${currentResult.stderr}`
+        );
+    }
+
+    const safeCurrent = currentVersion.replace(/'/g, "\\'");
+    const safeLatest = latestStable.replace(/'/g, "\\'");
+
+    const comparisonResult = await wpWithOutput(
+        `eval "echo version_compare('${safeCurrent}', '${safeLatest}', '>=') ? '1' : '0';"`
+    );
+
+    if (comparisonResult.failed || (comparisonResult.stdout ?? '').trim() !== '1') {
+        throw new Error(
+            `WordPress core is below the latest stable version.` +
+            `\nCurrent: ${currentVersion}` +
+            `\nLatest stable: ${latestStable}` +
+            `\nSTDOUT:\n${updatesResult.stdout}\nSTDERR:\n${updatesResult.stderr}`
         );
     }
 });

--- a/src/support/steps/general.ts
+++ b/src/support/steps/general.ts
@@ -275,12 +275,23 @@ Given('WordPress core is up to date', async function (this: ICustomWorld): Promi
         `eval "echo version_compare('${safeCurrent}', '${safeLatest}', '>=') ? '1' : '0';"`
     );
 
-    if (comparisonResult.failed || (comparisonResult.stdout ?? '').trim() !== '1') {
+    if (comparisonResult.failed) {
+        throw new Error(
+            `Failed to compare WordPress core version against latest stable.` +
+            `\nCurrent: ${currentVersion}` +
+            `\nLatest stable: ${latestStable}` +
+            `\nComparison STDOUT:\n${comparisonResult.stdout}\nComparison STDERR:\n${comparisonResult.stderr}` +
+            `\nCheck-update STDOUT:\n${updatesResult.stdout}\nCheck-update STDERR:\n${updatesResult.stderr}`
+        );
+    }
+
+    if ((comparisonResult.stdout ?? '').trim() !== '1') {
         throw new Error(
             `WordPress core is below the latest stable version.` +
             `\nCurrent: ${currentVersion}` +
             `\nLatest stable: ${latestStable}` +
-            `\nSTDOUT:\n${updatesResult.stdout}\nSTDERR:\n${updatesResult.stderr}`
+            `\nComparison STDOUT:\n${comparisonResult.stdout}\nComparison STDERR:\n${comparisonResult.stderr}` +
+            `\nCheck-update STDOUT:\n${updatesResult.stdout}\nCheck-update STDERR:\n${updatesResult.stderr}`
         );
     }
 });

--- a/src/support/steps/general.ts
+++ b/src/support/steps/general.ts
@@ -202,27 +202,53 @@ Given('I install plugin {string}', async function (pluginUrl) {
  * Allows prerelease/dev builds (RC, beta, dev) as long as they're >= latest stable numeric release.
  */
 Given('WordPress core is up to date', async function (): Promise<void> {
-    const current = (await wpWithOutput('core version')).stdout.trim();
+    const currentResult = await wpWithOutput('core version');
+    if (currentResult.failed) {
+        throw new Error(
+            `Failed to read current WordPress version via "wp core version".` +
+            `\nSTDOUT:\n${currentResult.stdout}\nSTDERR:\n${currentResult.stderr}`
+        );
+    }
 
-    const latestStable = (await wpWithOutput(
-        "core check-update --field=version"
-    )).stdout
+    const current = (currentResult.stdout ?? '').trim();
+    if (!current) {
+        throw new Error(
+            `Current WordPress version is empty.` +
+            `\nSTDOUT:\n${currentResult.stdout}\nSTDERR:\n${currentResult.stderr}`
+        );
+    }
+
+    const updatesResult = await wpWithOutput("core check-update --field=version");
+    if (updatesResult.failed) {
+        throw new Error(
+            `Failed to check available WordPress updates via "wp core check-update --field=version".` +
+            `\nSTDOUT:\n${updatesResult.stdout}\nSTDERR:\n${updatesResult.stderr}`
+        );
+    }
+
+    const latestStable = (updatesResult.stdout ?? '')
         .split('\n')
         .map(v => v.trim())
-        .filter(v => v && !v.includes('-')) // only stable (no RC, beta, dev suffixes)
+        .filter(v => v && !v.includes('-'))
         .sort((a, b) => a.localeCompare(b, undefined, { numeric: true }))
         .pop();
 
-    // If no stable updates → already latest or newer (RC/dev)
     if (!latestStable) return;
 
     const compare = await wpWithOutput(
-        `eval "echo version_compare('${current.replace(/'/g, "\\'")}'` +
-        `, '${latestStable.replace(/'/g, "\\'")}'` +
-        `, '>=') ? '1' : '0';"`
+        `eval "echo version_compare('${current.replace(/'/g, "\\'")}', '${latestStable.replace(/'/g, "\\'")}', '>=') ? '1' : '0';"`
     );
 
-    if (compare.stdout.trim() !== '1') {
+    if (compare.failed) {
+        throw new Error(
+            `Failed to compare WordPress core version against latest stable.` +
+            `\nCurrent: ${current}\nLatest stable: ${latestStable}` +
+            `\nComparison STDOUT:\n${compare.stdout}` +
+            `\nComparison STDERR:\n${compare.stderr}`
+        );
+    }
+
+    if ((compare.stdout ?? '').trim() !== '1') {
         throw new Error(
             `WordPress core is below the latest stable version.` +
             `\nCurrent: ${current}\nLatest stable: ${latestStable}` +


### PR DESCRIPTION
# Description

Fixes #354 

## Type of change

- [ ] New feature (non-breaking change which adds functionality).
- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] Enhancement (non-breaking change which improves an existing functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as before).
- [ ] Sub-task of #(issue number)
- [ ] Chore
- [ ] Release

## Detailed scenario

### What was tested

- Ran Query Monitor scenario with `@qm` tag to cover the step "WordPress core is up to date"
- Test is passing with prerelease/dev versions (example: 7.0-RC1, 7.0-RC1-62113) 
- Test still fails when current core is below latest stable, e.g. 6.8
- Ran also Smoke suite

### How to test

Same as above

### Affected Features & Quality Assurance Scope

- "WordPress core is up to date" step under general.ts
- Scenarios that include this shared step (notably `@qm`, and any other features reusing the same step)

## Technical description

### Documentation

The core-version gate now:

- Gets the current WordPress version using WP-CLI's `core version` command
- Gets available updates using WP-CLI's `core check-update --field=version` command
- Filters to only numeric WordPress versions (like 6.8, 6.8.1) by checking if the version string contains a dash character
- This automatically excludes prerelease versions (RC, beta, nightly, and build-suffixed versions)
- Selects the highest version number from the stable candidates
- Compares the current version against the latest stable version using PHP's `version_compare()` function
- Only fails when the current version is older than the latest stable; does not attempt to update

Key improvements from the earlier implementation:

- Removed complex JSON parsing and unnecessary type definitions
- Replaced regex-based stability detection with simple string filtering
- Code is now more readable and easier to maintain

### New dependencies

None

### Risks

Version format assumption risk: stable detection relies on presence of - character in prerelease versions
   - Mitigation: simple, well-understood filtering logic plus explicit error messages and safe fallback when no stable candidate exists
Behavioral scope risk: shared step affects all scenarios using it
   - Mitigation: logic is backward-compatible for stable-only environments and only relaxes false failures on prerelease/dev builds


# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [ ] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification

No new built-in test file was added because this change is covered by existing automated scenario that already executes the shared step.

# Additional Checks
- [ ] In the case of complex code, I wrote comments to explain it.
- [x] When possible, I prepared ways to observe the implemented system (logs, data, etc.).
- [x] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.)
