### PR TITLE
refactor open mobile menu

### DIFF
--- a/utils/helpers.ts
+++ b/utils/helpers.ts
@@ -680,9 +680,9 @@ export const openMobileMenu = async (page: Page): Promise<void> => {
         '.menu-mobile-toggle, .mobile_menu_bar, [data-open="#main-menu"], .menu-toggle-icon, button.fusion-mobile-selector[aria-controls="mobile-menu-header-menu"], #site-header-inner > div.oceanwp-mobile-menu-icon.clr.mobile-right > a > i, .menu-toggle, .nav-toggle, .hamburger'
     ).first();
 
-    await genericToggle.waitFor({ state: 'visible', timeout: 3000 }).catch(() => undefined);
+    await genericToggle.waitFor({ state: 'visible', timeout: 3000 });
 
-    if (await genericToggle.isVisible().catch(() => false)) {
+    if (await genericToggle.isVisible()) {
         await genericToggle.click();
         return;
     }

--- a/utils/helpers.ts
+++ b/utils/helpers.ts
@@ -672,20 +672,22 @@ export const isMobileMenuOpen = async (page: Page): Promise<boolean> => {
  * ```
  */
 export const openMobileMenu = async (page: Page): Promise<void> => {
-    await page.evaluate(() => {
-        if (!window.matchMedia("(max-width: 980px)").matches) return;
-        /* ---------- Specific theme selectors then generic selectors for the menu ---------- */
-        const genericToggle = document.querySelector<HTMLElement>(
-            '.menu-mobile-toggle, .mobile_menu_bar, [data-open="#main-menu"], .menu-toggle-icon, button.fusion-mobile-selector[aria-controls="mobile-menu-header-menu"], #site-header-inner > div.oceanwp-mobile-menu-icon.clr.mobile-right > a > i, .menu-toggle, .nav-toggle, .hamburger'
-        );
+    if (!await page.evaluate(() => window.matchMedia('(max-width: 980px)').matches)) {
+        return;
+    }
 
-        if (genericToggle && genericToggle.offsetParent !== null) {
-            genericToggle.click();
-            return;
-        }
+    const genericToggle = page.locator(
+        '.menu-mobile-toggle, .mobile_menu_bar, [data-open="#main-menu"], .menu-toggle-icon, button.fusion-mobile-selector[aria-controls="mobile-menu-header-menu"], #site-header-inner > div.oceanwp-mobile-menu-icon.clr.mobile-right > a > i, .menu-toggle, .nav-toggle, .hamburger'
+    ).first();
 
-        throw new Error("Mobile menu could not be opened: toggle button not found or not visible");
-    });
+    await genericToggle.waitFor({ state: 'visible', timeout: 3000 }).catch(() => undefined);
+
+    if (await genericToggle.isVisible().catch(() => false)) {
+        await genericToggle.click();
+        return;
+    }
+
+    throw new Error('Mobile menu could not be opened: toggle button not found or not visible');
 }
 
 /**


### PR DESCRIPTION
# Description

Fixes #356 
This should fix flaky failure when open mobile menu

## Type of change

- [ ] New feature (non-breaking change which adds functionality).
- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] Enhancement (non-breaking change which improves an existing functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as before).
- [ ] Sub-task of #(issue number)
- [ ] Chore
- [ ] Release

## Detailed scenario

### What was tested

- Run DJS tests pass
- Run smoke test pass

### How to test

As mentioned above

### Affected Features & Quality Assurance Scope

DJS test

## Technical description

### Documentation

1. Skip if not mobile — does nothing if viewport is wider than 980px.
2. Find the toggle button — looks for the first matching hamburger/menu button across several themes.
3. Wait up to 3s for it to appear (handles late-rendering like Avada).
4. Click it if visible, otherwise throw an error for the retry system to catch.

### New dependencies

N/A

### Risks

- If the menu takes more time to appear, the test will fail after 3 retries

# Mandatory Checklist

## Code validation

- [ ] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [ ] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [ ] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification

N/A
# Additional Checks
- [x] In the case of complex code, I wrote comments to explain it.
- [x] When possible, I prepared ways to observe the implemented system (logs, data, etc.).
- [ ] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.)
