### PR TITLE
updated file export IDs to "51" and "52"

### DIFF
--- a/src/features/settings-export-import.feature
+++ b/src/features/settings-export-import.feature
@@ -43,9 +43,9 @@ Feature: C2148 - Should not change the content of existing fields
         Given plugin is installed 'previous_stable'
         And plugin is activated
         And I enable all settings
-        And I export data '1'
+        And I export data '51'
         When I updated plugin to 'new_release'
         And I go to 'wp-admin/options-general.php?page=wprocket#file_optimization'
         And I save all settings
-        And I export data '2'
-        Then Nothing changed in settings '2' compared to '1'
+        And I export data '52'
+        Then Nothing changed in settings '52' compared to '51'

--- a/src/support/steps/settings-export-import.ts
+++ b/src/support/steps/settings-export-import.ts
@@ -29,21 +29,6 @@ Given('I disabled all settings', async function (this: ICustomWorld) {
 });
 
 /**
- * Executes the step to update to the latest version of the WP Rocket plugin.
- */
-Given('I updated to latest version', async function (this: ICustomWorld) {
-    await this.utils.uploadNewPlugin('./plugin/new_release.zip');
-    await this.page.waitForLoadState('load', { timeout: 30000 });
-    await expect(this.page).toHaveURL(/action=upload-plugin/); 
-    
-    // Replace current with uploaded
-    await this.page.locator('a:has-text("Replace current with uploaded")').click();
-
-    await this.page.waitForLoadState('load', { timeout: 30000 });
-    await expect(this.page).toHaveURL(/overwrite=update-plugin/); 
-});
-
-/**
  * Executes the step to import data.
  */
 When('I import data', async function (this: ICustomWorld) {


### PR DESCRIPTION
# Description

Fixes #352

Minimal change: changed the export file IDs from 1/2 to 51/52 for the last scenario. I chose 5 as it is the 5th scenario in [settings-export-import.feature](https://github.com/wp-media/wp-rocket-e2e/blob/develop/src/features/settings-export-import.feature). This removes cross-scenario dependency where the last scenario was comparing against export files generated in an earlier scenario, causing flakiness when run in isolation or with different environment states.
 +
remove unused update plugin step from [settings-export-import.ts](https://github.com/wp-media/wp-rocket-e2e/blob/a9201ee25b030370893d6624316129593df1d808/src/support/steps/settings-export-import.ts#L34) as we already use the one from general.ts

## Type of change

- [x] New feature (non-breaking change which adds functionality).
- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] Enhancement (non-breaking change which improves an existing functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as before).
- [ ] Sub-task of #(issue number)
- [ ] Chore
- [ ] Release

## Detailed scenario

### What was tested

Manually ran the last scenario "Should not change enabled fields with update" in isolation and as part of the full feature. Previously failed locally when run as part of the full feature due to file state contamination from earlier scenarios. Now passes consistently.
<img width="865" height="1297" alt="Screenshot 2026-03-30 at 14 39 43" src="https://github.com/user-attachments/assets/db7ccc13-48ce-4a27-8454-9402a16c0a5f" />


### How to test

Run the full feature `@export` or run `@smoke`

### Affected Features & Quality Assurance Scope

Impact is isolated to export-import test coverage. Test reliability improvement only. 
Other features/tests remain unaffected.

## Technical description

### Documentation

The root cause was that the 5th scenario reused export file IDs (1 and 2) from earlier scenarios, creating an accidental dependency. When scenarios ran in sequence, file 2 from the 2nd scenario was retained and used in comparisons by the 5th scenario. This worked on remote (where file state may have differed) but failed locally, where strict file reuse occurred.

Solution: assign unique IDs per scenario. The 5th scenario now exports to files 51 and 52, ensuring it only compares its own exports and removes the cross-scenario coupling.

### New dependencies

None

### Risks

None

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification

N/A

# Additional Checks
- [ ] In the case of complex code, I wrote comments to explain it.
- [ ] When possible, I prepared ways to observe the implemented system (logs, data, etc.).
- [ ] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.)
