### PR TITLE
Fix/adapt after hook to bulk delete change in 5.6.8

### DIFF
--- a/src/backwpup/support/hooks.ts
+++ b/src/backwpup/support/hooks.ts
@@ -93,6 +93,6 @@ async function deleteAllData(page: Page): Promise<void> {
     await page.selectOption('select[name="bulk_actions"]', 'delete');
     await page.click('button#bulk-actions-apply');
     await page.waitForSelector('button#js-backwpup-bulk-delete-backups', { timeout: 5000 });
-    await page.click('button#js-backwpup-bulk-delete-backups');
+    await page.click('button.js-backwpup-bulk-delete-backups');
     await page.waitForLoadState('networkidle');
 }

--- a/src/backwpup/support/hooks.ts
+++ b/src/backwpup/support/hooks.ts
@@ -89,7 +89,7 @@ async function deleteAllData(page: Page): Promise<void> {
     for (let i = 0; i < count; i++) {
         await checkboxLabels.nth(i).click();
     }
-    const message = 'Delete button not found, plugin version might be earlier than 5.6.7.';
+    const message = 'Delete button not found, plugin version might be earlier than 5.6.8.';
     await page.selectOption('select[name="bulk_actions"]', 'delete');
     await page.click('button#bulk-actions-apply');
     const confirmDialogSelector = 'button.js-backwpup-bulk-delete-backups';

--- a/src/backwpup/support/hooks.ts
+++ b/src/backwpup/support/hooks.ts
@@ -92,7 +92,7 @@ async function deleteAllData(page: Page): Promise<void> {
 
     await page.selectOption('select[name="bulk_actions"]', 'delete');
     await page.click('button#bulk-actions-apply');
-    await page.waitForSelector('button#js-backwpup-bulk-delete-backups', { timeout: 5000 });
+    await page.waitForSelector('button.js-backwpup-bulk-delete-backups', { timeout: 5000 });
     await page.click('button.js-backwpup-bulk-delete-backups');
     await page.waitForLoadState('networkidle');
 }

--- a/src/backwpup/support/hooks.ts
+++ b/src/backwpup/support/hooks.ts
@@ -89,10 +89,16 @@ async function deleteAllData(page: Page): Promise<void> {
     for (let i = 0; i < count; i++) {
         await checkboxLabels.nth(i).click();
     }
-
+    const message = 'Delete button not found, plugin version might be earlier than 5.6.7.';
     await page.selectOption('select[name="bulk_actions"]', 'delete');
     await page.click('button#bulk-actions-apply');
-    await page.waitForSelector('button.js-backwpup-bulk-delete-backups', { timeout: 5000 });
-    await page.click('button.js-backwpup-bulk-delete-backups');
+    const confirmDialogSelector = 'button.js-backwpup-bulk-delete-backups';
+    try {
+        // Previous versions of the plugin did not have a confirmation dialog, so we wait for it and click it if it appears, but if it doesn't appear after 5 seconds, we catch the error and log a message, preventing the test from failing due to a timeout error. This allows the cleanup process to work with both older and newer versions of the plugin.
+        await page.waitForSelector(confirmDialogSelector, { timeout: 5000 });
+        await page.click(confirmDialogSelector);
+    } catch {
+        console.log(message);
+    }
     await page.waitForLoadState('networkidle');
 }

--- a/src/backwpup/support/hooks.ts
+++ b/src/backwpup/support/hooks.ts
@@ -92,5 +92,7 @@ async function deleteAllData(page: Page): Promise<void> {
 
     await page.selectOption('select[name="bulk_actions"]', 'delete');
     await page.click('button#bulk-actions-apply');
+    await page.waitForSelector('button#js-backwpup-bulk-delete-backups', { timeout: 5000 });
+    await page.click('button#js-backwpup-bulk-delete-backups');
     await page.waitForLoadState('networkidle');
 }


### PR DESCRIPTION
# Description

Fixes Failed tests since BackWpup 5.6.8

On 5.6.8, a modal to confirm backup deletion for bulk deletion was added. This PR added a new click on the modal to make sure the backups are removed.

### 5.6.8 results:
<img width="1175" height="673" alt="image" src="https://github.com/user-attachments/assets/cfa6a42d-824d-461b-978d-fab5e68785bb" />

### 5.6.6 results:
<img width="651" height="66" alt="image" src="https://github.com/user-attachments/assets/33d4d5e7-a378-43da-baf2-7bbbf58e8062" />


## Type of change

- [ ] New feature (non-breaking change which adds functionality).
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] Enhancement (non-breaking change which improves an existing functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as before).
- [ ] Sub-task of #(issue number)
- [ ] Chore
- [ ] Release

## Detailed scenario

### What was tested

Ran all storage tests.

### How to test

Run `node ./node_modules/@cucumber/cucumber/bin/cucumber-js -p default --tags @bwpupstorage`

### Affected Features & Quality Assurance Scope

Only "after" hook to clear was changed

## Technical description

### Documentation

Added these:

```
    await page.waitForSelector('button.js-backwpup-bulk-delete-backups', { timeout: 5000 });
    await page.click('button.js-backwpup-bulk-delete-backups');
```

### New dependencies

N/A

### Risks

N/A

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification

N/A
