### PR TITLE
moves step to enable addons as first in the list from enableAllOptions

### DIFF
--- a/src/features/settings-export-import.feature
+++ b/src/features/settings-export-import.feature
@@ -43,6 +43,7 @@ Feature: C2148 - Should not change the content of existing fields
         Given plugin is installed 'previous_stable'
         And plugin is activated
         And I enable all settings
+        And I save all settings
         And I export data '51'
         When I updated plugin to 'new_release'
         And I go to 'wp-admin/options-general.php?page=wprocket#file_optimization'

--- a/src/features/settings-export-import.feature
+++ b/src/features/settings-export-import.feature
@@ -43,7 +43,6 @@ Feature: C2148 - Should not change the content of existing fields
         Given plugin is installed 'previous_stable'
         And plugin is activated
         And I enable all settings
-        And I save all settings
         And I export data '51'
         When I updated plugin to 'new_release'
         And I go to 'wp-admin/options-general.php?page=wprocket#file_optimization'

--- a/utils/page-utils.ts
+++ b/utils/page-utils.ts
@@ -509,6 +509,12 @@ export class PageUtils {
 
         this.sections.optionState = true;
 
+        if(await this.sections.doesSectionExist('addons')) {
+            // Enable all settings for Addons.
+            await this.sections.set("addons").visit();
+            await this.sections.massToggle();
+        }
+
         if (await this.sections.doesSectionExist('cache')) {
              // Enable all settings for cache section.
             await this.sections.set("cache").visit();
@@ -566,12 +572,6 @@ export class PageUtils {
             await this.saveSettings();
             await expect(this.page.getByText('Settings saved.')).toBeVisible();
             await this.page.locator('#setting-error-settings_updated > button').click();
-        }
-
-        if(await this.sections.doesSectionExist('addons')) {
-            // Enable all settings for Addons.
-            await this.sections.set("addons").visit();
-            await this.sections.massToggle();
         }
 
         if(await this.sections.doesSectionExist('heartbeat')) {


### PR DESCRIPTION
# Description

Fixes #364

## Type of change

- [ ] New feature (non-breaking change which adds functionality).
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] Enhancement (non-breaking change which improves an existing functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as before).
- [ ] Sub-task of #(issue number)
- [ ] Chore
- [ ] Release

## Detailed scenario
The export/import scenario “Should not change enabled fields with update” could fail due to value format mismatches between versions (for example empty string/"1" versus 0/1 after update and re-save).
This PR moves the step that enables add-ons to the beginning of the sequence in [enableAllOptions](https://github.com/wp-media/wp-rocket-e2e/blob/2d8fce71feaa24b1d4485b37068ec35d8b7ab636/utils/page-utils.ts#L507). This ensures that settings are re-saved at least once via the Save button after toggling the add-ons, thereby eliminating any value format mismatches between versions.

### What was tested
Ran npm run test:export five consecutive times.
Result: all tests passed in every run.


### How to test

Run `npm run test:export` and verify that:
1. The scenario “Should not change enabled fields with update” passes consistently.
2. Export comparison between data 51 and 52 no longer reports false negatives caused by format normalization.

### Affected Features & Quality Assurance Scope

Only the "enableAllOptions" in page-utils.ts, moved https://github.com/wp-media/wp-rocket-e2e/blob/2d8fce71feaa24b1d4485b37068ec35d8b7ab636/utils/page-utils.ts#L571
to the beginning of the sequence. 

## Technical description
Moved "enableAllOptions" in page-utils.ts to the beginning of the sequence. 

### Documentation

No documentation update required (test scenario adjustment only).

### New dependencies

N/A

### Risks

N/A

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [ ] I implemented built-in tests to cover the new/changed code.

## Code style

- [ ] I wrote a self-explanatory code about what it does.
- [ ] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [ ] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification

N/A

# Additional Checks
- [ ] In the case of complex code, I wrote comments to explain it.
- [ ] When possible, I prepared ways to observe the implemented system (logs, data, etc.).
- [ ] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.)
