### PR TITLE
Exclude cdn iframe URL from broken links test

### DIFF
--- a/src/support/steps/broken-links.ts
+++ b/src/support/steps/broken-links.ts
@@ -67,7 +67,12 @@ Then('WP Rocket settings links are not broken', async function (this: ICustomWor
     }
 
     // Validate all collected URLs, excluding URLs that may trigger transactional side effects
-    const skipPatterns = [/\/renew(?:\/|$|\?)/i, /\/upgrade(?:\/|$|\?)/i, /\/express-checkout(?:\/|$|\?)/i];
+    const skipPatterns = [
+        /\/renew(?:\/|$|\?)/i,
+        /\/upgrade(?:\/|$|\?)/i,
+        /\/express-checkout(?:\/|$|\?)/i,
+        /\/cdn\/iframe(?:\/|$|\?)/i,
+    ];
     const brokenLinks = await validateLinks(this.page, normalizedUrls, currentHost, skipPatterns);
 
     // Report all broken links at once


### PR DESCRIPTION
# Description
- This PR excludes the link that has /cdn/iframe from the broken links test 
- requests here from auto -e2e should stop unless we add tests to interact with CDN https://group-onecom.slack.com/archives/C08F4LZB2QG/p1776841990394609?thread_ts=1776839550.830359&cid=C08F4LZB2QG
## Type of change

- [ ] New feature (non-breaking change which adds functionality).
- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] Enhancement (non-breaking change which improves an existing functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as before).
- [ ] Sub-task of #(issue number)
- [ ] Chore
- [ ] Release

## Detailed scenario

### What was tested

- Run broken test => pass
- Smoke test => pass

### How to test

As mentioned above

### Affected Features & Quality Assurance Scope

- Broken links test

## Technical description

### Documentation

- Just added cdn/iframe to excluded links

### New dependencies

N/A

### Risks

- If CDN URL is broken, we won't know from e2e

# Mandatory Checklist

## Code validation

- [ ] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [ ] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [ ] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [ ] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification

N/A

# Additional Checks
- [x] In the case of complex code, I wrote comments to explain it.
- [ ] When possible, I prepared ways to observe the implemented system (logs, data, etc.).
- [ ] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.)
