### PR TITLE
fix: fixed #375

### DIFF
--- a/src/backwpup/steps/general.ts
+++ b/src/backwpup/steps/general.ts
@@ -161,6 +161,21 @@ When('I Schedule backup', async function (this: ICustomWorld) {
  *
  * Reads each row of `table#backwpup-backup-history` and returns structured data.
  *
+ * **Supports two table layouts:**
+ *
+ * - **Pre-5.6.9 (old layout):** Failed rows merge columns 3 ("Stored on") and 4 ("Data")
+ *   into a single `<td colspan="2">` containing the failure message. In this layout,
+ *   `td:nth-child(5)` does not exist on failed rows, and failure is detected from col 4.
+ *
+ * - **5.6.9+ (new layout):** All columns remain separate. Column 4 always contains
+ *   the "Stored on" icon/tooltip (even on failure), and column 5 ("Data"/"Status")
+ *   contains the failure message (e.g., "FTP backup failed"). The failure text now
+ *   includes the storage provider name.
+ *
+ * **Version detection:** We count the `<td>` elements in each row. If there are 6 columns
+ * (checkbox, date, type, stored on, data, actions), it's the new layout. If fewer
+ * (due to colspan merging), it's the old layout.
+ *
  * **Text extraction strategy (important — do not change without testing):**
  *
  * - **Date (column 2)** → `innerText()`:
@@ -194,16 +209,36 @@ const captureBackupTableData = async (page: Page): Promise<BackupRowData[]> => {
         // textContent() captures ALL text nodes regardless of visibility — including the
         // hidden column header on the first line and the data value on the last line.
         const rawType = (await row.locator('td:nth-child(3)').textContent()) || '';
-        const rawStoredOnOrError = (await row.locator('td:nth-child(4)').textContent()) || '';
 
-        // Detect failure from raw text before cleanup, since "failed" may be in hidden text.
-        const failed = rawStoredOnOrError.toLowerCase().includes('failed');
+        // Detect layout version by counting <td> elements in this row.
+        // New layout (5.6.9+): 6 columns (checkbox, date, type, stored on, data/status, actions).
+        // Old layout (pre-5.6.9): Failed rows have 5 columns due to colspan="2" merging cols 3+4.
+        const tdCount = await row.locator('td').count();
+        const isNewLayout = tdCount >= 6;
+
+        let failed: boolean;
+        let storedOn: string;
+
+        if (isNewLayout) {
+            // New layout: col 4 = Stored on (always present), col 5 = Data/Status.
+            const rawStoredOn = (await row.locator('td:nth-child(4)').textContent()) || '';
+            const rawStatus = (await row.locator('td:nth-child(5)').textContent()) || '';
+
+            failed = rawStatus.toLowerCase().includes('failed');
+            storedOn = extractLastMeaningfulLine(rawStoredOn);
+        } else {
+            // Old layout: on failed rows, cols 3+4 are merged (colspan="2") into td:nth-child(4).
+            // On success rows, col 4 = Stored on.
+            const rawStoredOnOrError = (await row.locator('td:nth-child(4)').textContent()) || '';
+
+            failed = rawStoredOnOrError.toLowerCase().includes('failed');
+            storedOn = !failed ? extractLastMeaningfulLine(rawStoredOnOrError) : '';
+        }
 
         // Date may span multiple lines ("Apr 13, 2026\nat 10:09pm") — collapse to one line.
         const date = normalizeCellText(rawDate);
-        // Type/storedOn raw text: first line = column header label, last line = actual value.
+        // Type raw text: first line = column header label, last line = actual value.
         const type = extractLastMeaningfulLine(rawType);
-        const storedOn = !failed ? extractLastMeaningfulLine(rawStoredOnOrError) : '';
 
         backups.push({ date, type, storedOn, failed });
     }


### PR DESCRIPTION
# Description

Fixes #375 

Checks the number of columns in the table per backup to see if it is the version 5.6.8 or 5.6.9 (Pre 5.6.8 does not have failed status in history), then extracts the failed status.

5.6.8:
<img width="570" height="206" alt="image" src="https://github.com/user-attachments/assets/188fbaa8-e562-4b07-92d5-c74136e61027" />


5.6.9+:
<img width="531" height="269" alt="image" src="https://github.com/user-attachments/assets/e061c74f-dac2-432e-bf9a-caf59e8afbe3" />


## Type of change

- [ ] New feature (non-breaking change which adds functionality).
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] Enhancement (non-breaking change which improves an existing functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as before).
- [ ] Sub-task of #(issue number)
- [ ] Chore
- [ ] Release

## Detailed scenario

### What was tested

All the tests run without issues

### How to test

Execute suite and make some backups fail (in 5.6.8 and 5.6.9)

### Affected Features & Quality Assurance Scope

Failed backup detection

## Technical description

### Documentation

Counts the colums to determine the plugins version.

### New dependencies

N/A

### Risks

N/A

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.