### PR TITLE
[BackWPup] Add database only and files only tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,9 @@
     "test:bwpupstorage": "$npm_package_config_testCommand --tags @bwpupstorage",
     "test:bwpuponboarding": "$npm_package_config_testCommand --tags @bwpuponboarding",
     "test:bwpupsmoke": "$npm_package_config_testCommand --tags @bwpupsmoke",
-    "test:bwpup": "$npm_package_config_testCommand --tags @bwpup"
+    "test:bwpup": "$npm_package_config_testCommand --tags @bwpup",
+    "test:scenario": "$npm_package_config_testCommand --name \"$npm_config_scenario\"",
+    "test:tags": "$npm_package_config_testCommand --tags \"$npm_config_tags\""
   },
   "repository": {
     "type": "git",

--- a/src/backwpup/features/onboarding.feature
+++ b/src/backwpup/features/onboarding.feature
@@ -1,4 +1,4 @@
-@bwpup @bwpupsetup @bwpupsmoke
+@bwpup @bwpupsetup @bwpupsmoke @bwpuponboarding
 Feature: BackWpUp Onboarding
 
   Background:
@@ -17,6 +17,30 @@ Feature: BackWpUp Onboarding
     And I go '/wp-admin/admin.php?page=backwpup'
     And I should see 'mixed' job cards
     Then the backup should be added to the table
+
+  Scenario: Onboarding For Only Files data
+    When I go '/wp-admin/admin.php?page=backwpup'
+    Then all database tables should be selected
+    And all files directory should be selected
+    When I deactivate 'database' backup data
+    And I click '.js-backwpup-onboarding-step-2' button to continue
+    And I click '.js-backwpup-onboarding-step-3' button to continue
+    And I Configure web server storage
+    And I go '/wp-admin/admin.php?page=backwpup'
+    Then the backup should be added to the table
+    And I should see 'files' job cards
+
+  Scenario: Onboarding For Only Database data
+    When I go '/wp-admin/admin.php?page=backwpup'
+    Then all database tables should be selected
+    And all files directory should be selected
+    When I deactivate 'files' backup data
+    And I click '.js-backwpup-onboarding-step-2' button to continue
+    And I click '.js-backwpup-onboarding-step-3' button to continue
+    And I Configure web server storage
+    And I go '/wp-admin/admin.php?page=backwpup'
+    Then the backup should be added to the table
+    And I should see 'database' job cards
 
   Scenario: Onboarding with separate frequency
     And I go '/wp-admin/admin.php?page=backwpup'
@@ -39,7 +63,6 @@ Feature: BackWpUp Onboarding
     When I Configure web server storage
     And I go '/wp-admin/admin.php?page=backwpup'
     And I should see 'both' job cards
-
 
   Scenario: Should respect data selection
     And I go '/wp-admin/admin.php?page=backwpup'

--- a/src/backwpup/steps/general.ts
+++ b/src/backwpup/steps/general.ts
@@ -23,8 +23,19 @@ Then('the backup should be added to the table', async function (this: ICustomWor
     await this.page.reload();
     await this.page.waitForLoadState('networkidle');
 
-    const newRowCount = await this.page.locator('table#backwpup-backup-history tbody tr').count();
-    expect(newRowCount).toBe(1);
+    // Scroll the table itself into the viewport (single-element locator avoids strict mode violation)
+    await this.page.locator('table#backwpup-backup-history').scrollIntoViewIfNeeded();
+    // Wait for the scroll animation to settle before reading table state
+    await this.page.waitForTimeout(500);
+
+    const currentBackups = await captureBackupTableData(this.page);
+
+    expect(currentBackups.length).toBe(1);
+
+    const failedBackups = currentBackups.filter(backup => backup.failed);
+    if (failedBackups.length > 0) {
+        throw new Error(`Expected no failed backups, but found ${failedBackups.length} failed backup(s). Details: ${JSON.stringify(failedBackups)}`);
+    }
 });
 
 Then('{string} backup is generated and added to history', async function (this: ICustomWorld, backupNumber: string) {

--- a/src/backwpup/steps/onboarding.ts
+++ b/src/backwpup/steps/onboarding.ts
@@ -148,6 +148,58 @@ When('I uncheck the {string} from database backup option', async function (this:
     await expect(this.page.locator('#sidebar-select-tables')).not.toBeInViewport();
 });
 
+/**
+ * Deactivate a backup data type toggle, ensuring the other one remains active.
+ * At least one of "files" or "database" must remain active at all times.
+ * @step
+ * @param {string} dataType - The backup type to deactivate ('files' or 'database').
+ */
+When('I deactivate {string} backup data', async function (this: ICustomWorld, dataType: string) {
+    // Named checkbox id variables for clarity and easy reuse
+    const filesCheckboxId = 'backup_files';
+    const databaseCheckboxId = 'backup_database';
+
+    const dataTypeConfig: { [key: string]: { checkboxId: string; otherCheckboxId: string } } = {
+        files: {
+            checkboxId: filesCheckboxId,
+            otherCheckboxId: databaseCheckboxId,
+        },
+        database: {
+            checkboxId: databaseCheckboxId,
+            otherCheckboxId: filesCheckboxId,
+        },
+    };
+
+    if (!dataTypeConfig[dataType]) {
+        throw new Error(`Invalid backup data type: "${dataType}". Expected "files" or "database".`);
+    }
+
+    const { checkboxId, otherCheckboxId } = dataTypeConfig[dataType];
+    const targetCheckbox = this.page.locator(`#${checkboxId}`);
+    const otherCheckbox = this.page.locator(`#${otherCheckboxId}`);
+
+    // Ensure the other backup type is active before deactivating the target,
+    // since at least one must remain active at all times.
+    const otherIsChecked = await otherCheckbox.isChecked();
+    if (!otherIsChecked) {
+        await this.page.locator(`label[for="${otherCheckboxId}"]`).click();
+        await expect(otherCheckbox).toBeChecked();
+    }
+
+    // Deactivate the target toggle only if it is currently active.
+    const targetIsChecked = await targetCheckbox.isChecked();
+    if (targetIsChecked) {
+        await this.page.locator(`label[for="${checkboxId}"]`).click();
+    }
+
+    // Assert final state: target is deactivated, other remains active.
+    await expect(targetCheckbox).not.toBeChecked();
+    await expect(otherCheckbox).toBeChecked();
+
+    // Brief settle time to allow the UI to stabilize before the caller continues.
+    await this.page.waitForTimeout(500);
+});
+
 const validateCheckboxSelection = async (page: Page, containerSelector: string, shouldBeChecked: boolean = true): Promise<void> => {
     const allCheckboxes = page.locator(`${containerSelector}`);
     const count = await allCheckboxes.count();


### PR DESCRIPTION
# Description

Adds database-only and files-only scenarios.

It also improves the backup counting logic to catch when a backup failed, making the test fail as well.

And added two scripts to the `package.json` to run specific scenarios or specific tags easily with:

```bash
npm run test:tags --tags="@bwpupdownload"
```

```bash
# For one scenario
npm run test:scenario --scenario="Onboarding For Only Files data"

# or

# For multiple scenarios separating them with `|`
npm run test:scenario --scenario="Onboarding For Only Files data|Onboarding For Only Database data|Onboarding For Mixed data"
```

All test suite results:
<img width="663" height="324" alt="image" src="https://github.com/user-attachments/assets/22ac208a-3b04-48d1-a90f-7e7797e5c32b" />


## Type of change

- [x] New feature (non-breaking change which adds functionality).
- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] Enhancement (non-breaking change which improves an existing functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as before).
- [ ] Sub-task of #(issue number)
- [ ] Chore
- [ ] Release

## Detailed scenario

### What was tested

Ran all the tests and also ran the tests added to make sure nothing breaks and new tests work fine.

### How to test

Run the added scenarios:

```bash
npm run test:scenario --scenario="Onboarding For Only Files data|Onboarding For Only Database data"
```

### Affected Features & Quality Assurance Scope

Onboarding feature and `the backup should be added to the table` step

## Technical description

### Documentation

Adds database-only and files-only scenarios and does some improvements.

### New dependencies

N/A

### Risks

N/A

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification
N/A
