### PR TITLE
fix failed tests with 3.22+ of WPR

### DIFF
--- a/src/support/steps/enable-all-features.ts
+++ b/src/support/steps/enable-all-features.ts
@@ -20,6 +20,7 @@ import { WP_BASE_URL } from '../../../config/wp.config';
  */
 Then('page loads successfully', async function (this: ICustomWorld) {
     const response = await this.page!.goto(WP_BASE_URL);
+    expect(response, 'Navigation failed or was aborted').not.toBeNull();
     expect(response?.status()).not.toEqual(500);
     expect(response?.status()).not.toEqual(404);
     await expect(this.page!.locator('body')).toBeVisible();

--- a/src/support/steps/enable-all-features.ts
+++ b/src/support/steps/enable-all-features.ts
@@ -19,10 +19,10 @@ import { WP_BASE_URL } from '../../../config/wp.config';
  * Executes the step to assert successful page loading.
  */
 Then('page loads successfully', async function (this: ICustomWorld) {
-    this.page.on('response', async (response) => {
-        expect(response.status()).not.toEqual(500);
-        expect(response.status()).not.toEqual(404);
-    });
-    await this.page.goto(WP_BASE_URL);
+    const response = await this.page!.goto(WP_BASE_URL);
+    expect(response?.status()).not.toEqual(500);
+    expect(response?.status()).not.toEqual(404);
+    await expect(this.page!.locator('body')).toBeVisible();
+    await expect(this.page!.getByText('There has been a critical error')).not.toBeVisible();
     //Todo: future enahancement, we can do VR compared to nowprocket but if no CNAME is set or correct CNAME is set
 });

--- a/src/support/steps/settings-export-import.ts
+++ b/src/support/steps/settings-export-import.ts
@@ -123,10 +123,10 @@ Then('data {string} is exported correctly', async function (fileNo: string) {
     const exportedSettings: ExportedSettings = JSON.parse(jsonData);
     const version = parseFloat(exportedSettings['version'].toString());
 
-    if (version >= 3.16) {
-        const exclusions: Array<string> = ['do_caching_mobile_files', 'cache_mobile'];
-        enabledOptions.push(...exclusions);
-    }
+    // if (version >= 3.16) {
+    //     const exclusions: Array<string> = ['do_caching_mobile_files', 'cache_mobile'];
+    //     enabledOptions.push(...exclusions);
+    // }
     
     const failingSettings = await isExportedCorrectly(exportedSettings, enabledOptions);
     expect(failingSettings, `Settings not exported correctly, unexpected non-zero values: ${failingSettings.join(', ')}`).toHaveLength(0);

--- a/src/support/steps/settings-export-import.ts
+++ b/src/support/steps/settings-export-import.ts
@@ -120,14 +120,7 @@ Then('data is imported correctly', async function (this: ICustomWorld) {
  */
 Then('data {string} is exported correctly', async function (fileNo: string) {
     const jsonData = await readAnyFile(`./plugin/exported_settings/wp-rocket-settings-test-2023-00-0${fileNo}-64e7ada0d3b70.json`);
-    const exportedSettings: ExportedSettings = JSON.parse(jsonData);
-    const version = parseFloat(exportedSettings['version'].toString());
-
-    // if (version >= 3.16) {
-    //     const exclusions: Array<string> = ['do_caching_mobile_files', 'cache_mobile'];
-    //     enabledOptions.push(...exclusions);
-    // }
-    
+    const exportedSettings: ExportedSettings = JSON.parse(jsonData);  
     const failingSettings = await isExportedCorrectly(exportedSettings, enabledOptions);
     expect(failingSettings, `Settings not exported correctly, unexpected non-zero values: ${failingSettings.join(', ')}`).toHaveLength(0);
 });

--- a/src/support/steps/settings-export-import.ts
+++ b/src/support/steps/settings-export-import.ts
@@ -128,8 +128,8 @@ Then('data {string} is exported correctly', async function (fileNo: string) {
         enabledOptions.push(...exclusions);
     }
     
-    const validatedExportedSettings = await isExportedCorrectly(exportedSettings, enabledOptions);
-    expect(validatedExportedSettings, 'Settings was not exported correctly.').toBeTruthy();
+    const failingSettings = await isExportedCorrectly(exportedSettings, enabledOptions);
+    expect(failingSettings, `Settings not exported correctly, unexpected non-zero values: ${failingSettings.join(', ')}`).toHaveLength(0);
 });
 
 

--- a/utils/exclusions.ts
+++ b/utils/exclusions.ts
@@ -35,7 +35,6 @@ export const uiReflectedSettings = [
     'do_cloudflare',
     'sucury_waf_cache_sync',
     'control_heartbeat',
-    'cdn',
     'varnish_auto_purge',
     'image_dimensions',
     'delay_js', 
@@ -58,5 +57,6 @@ export const diffChecker = [
     "minify_css_key",
     "minify_js_key",
     "auto_preload_fonts",
+    "cdn",
     "analytics_enabled"
 ];

--- a/utils/exclusions.ts
+++ b/utils/exclusions.ts
@@ -15,8 +15,6 @@ export const uiReflectedSettings = [
     'remove_unused_css',
     'async_css',
     'cache_logged_user',
-    'cache_mobile',
-    'do_caching_mobile_files',
     'minify_css',
     'minify_js',
     'minify_concatenate_js',
@@ -42,6 +40,9 @@ export const uiReflectedSettings = [
 
 export const enabledOptions = [
     "lazyload",
+    'cache_mobile',
+    'do_caching_mobile_files',
+    "cdn",
 ];
 
 /**
@@ -57,6 +58,5 @@ export const diffChecker = [
     "minify_css_key",
     "minify_js_key",
     "auto_preload_fonts",
-    "cdn",
     "analytics_enabled"
 ];

--- a/utils/helpers.ts
+++ b/utils/helpers.ts
@@ -182,7 +182,8 @@ export const readAnyFile = async (file: string): Promise<string> => {
  * @param {string} exception - Object key to exclude from the check.
  * @returns {Promise<boolean>} - A Promise that resolves to true if settings are exported correctly, false otherwise.
  */
-export const isExportedCorrectly = async (exportedSettings: ExportedSettings, exception: Array<string>): Promise< boolean > => {
+export const isExportedCorrectly = async (exportedSettings: ExportedSettings, exception: Array<string>): Promise<string[]> => {
+    const failingSettings: string[] = [];
     for (const key in exportedSettings) {
         for (const option of uiReflectedSettings) {
             if (exception.includes(key)) {
@@ -190,12 +191,11 @@ export const isExportedCorrectly = async (exportedSettings: ExportedSettings, ex
             }
 
             if (key === option && exportedSettings[key] !== 0) {
-                return false;
+                failingSettings.push(`${key}=${exportedSettings[key]}`);
             }
         }
-     }
-
-     return true;
+    }
+    return failingSettings;
 }
 
 /**

--- a/utils/helpers.ts
+++ b/utils/helpers.ts
@@ -179,8 +179,8 @@ export const readAnyFile = async (file: string): Promise<string> => {
  * Check that settings are exported correctly, excluding a specified option.
  *
  * @param {ExportedSettings} exportedSettings - Object of exported settings.
- * @param {string} exception - Object key to exclude from the check.
- * @returns {Promise<boolean>} - A Promise that resolves to true if settings are exported correctly, false otherwise.
+ * @param {Array<string>} exception - Array of setting keys to exclude from the check.
+ * @returns {Promise<string[]>} - A Promise that resolves to an array of failing settings (key=value), empty if all are correct.
  */
 export const isExportedCorrectly = async (exportedSettings: ExportedSettings, exception: Array<string>): Promise<string[]> => {
     const failingSettings: string[] = [];

--- a/utils/page-utils.ts
+++ b/utils/page-utils.ts
@@ -456,12 +456,12 @@ export class PageUtils {
         if(await this.sections.doesSectionExist('cdn')) {
             // Disable all settings for CDN.
             await this.sections.set("cdn").visit();
+            await this.page.locator("button[data-cdn-driver='your-own-cdn']").click();
             await this.sections.massToggle();
-            await this.sections.fill("cnames", "");
             await this.saveSettings();
             await expect(this.page.getByText('Settings saved.')).toBeVisible();
             await this.page.locator('#setting-error-settings_updated > button').click();
-           
+
         }
 
         if(await this.sections.doesSectionExist('addons')) {
@@ -567,6 +567,9 @@ export class PageUtils {
         if(await this.sections.doesSectionExist('cdn')) {
             // Enable all settings for CDN.
             await this.sections.set("cdn").visit();
+            // switch to YOCDN
+            await this.page.locator("button[data-cdn-driver='your-own-cdn']").click();
+            await this.page.getByRole('button', { name: 'Add CNAME' }).click();
             await this.sections.toggle("cdn");
             await this.sections.fill("cnames", "test.example.com");
             await this.saveSettings();


### PR DESCRIPTION
# Description
Done discussion with discussion with Claude

Fixes #381 
Since WPR 3.22+ , tests are failing due to new CDN UI, this PR fix failed tests

## Type of change

- [ ] New feature (non-breaking change which adds functionality).
- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] Enhancement (non-breaking change which improves an existing functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as before).
- [ ] Sub-task of #(issue number)
- [ ] Chore
- [ ] Release

## Detailed scenario

### What was tested

- Run smoke tests , pass
- Run all e2e pass

### How to test

- Make sure that previous_stable is 3.22.0.1
- New_release is 3.22.0.2 or 3.22.0.3
- Run smoke tests

### Affected Features & Quality Assurance Scope

- Import/Export feature
- Enable or disable all settings steps

## Technical description

### Documentation

- Exclude cdn from settings comparison {cdn is forced true since 3.22+, disable all settings won't set it to false}
- Show mismatched item in terminal when compare settings fail
- Update cdn selector
- Page loaded successfully step just confirm page itself loads, no critical error (not consider any console error/warning check in this step)

### New dependencies

- Previous_stable is 3.22.0.1+

### Risks

- Test may fail if previous stable is < 3.22 as selectors are different

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [ ] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [ ] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification

N/A
# Additional Checks
- [ ] In the case of complex code, I wrote comments to explain it.
- [ ] When possible, I prepared ways to observe the implemented system (logs, data, etc.).
- [x] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.)
