### PR TITLE
capture cache clear regression using helper

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "test:renewal": "$npm_package_config_testCommand --tags @renewal",
     "test:promo": "$npm_package_config_testCommand --tags @promo",
     "test:notices": "$npm_package_config_testCommand --tags @notices",
+    "test:cache": "$npm_package_config_testCommand --tags @cache",
     "test:qm": "$npm_package_config_testCommand --tags @qm",
     "healthcheck": "ts-node healthcheck.ts",
     "push-report": "ts-node report.ts",

--- a/src/features/cache.feature
+++ b/src/features/cache.feature
@@ -1,0 +1,15 @@
+@setup @smoke @local @cache @test
+Feature: Cache Clear
+
+    Background:
+        Given I am logged in
+        And plugin is installed 'new_release'
+        And plugin is activated
+
+     Scenario: Shouldn't clear cache when refresh admin
+        Given I log out
+        And I visit site url
+        When I am logged in
+        Then homepage cache should exist
+        When I refresh WP Rocket settings
+        Then homepage cache should not be regenerated

--- a/src/features/cache.feature
+++ b/src/features/cache.feature
@@ -1,4 +1,4 @@
-@setup @smoke @local @cache @test
+@setup @smoke @local @cache 
 Feature: Cache Clear
 
     Background:
@@ -6,7 +6,7 @@ Feature: Cache Clear
         And plugin is installed 'new_release'
         And plugin is activated
 
-     Scenario: Shouldn't clear cache when refresh admin
+    Scenario: Shouldn't clear cache when refresh admin
         Given I log out
         And I visit site url
         When I am logged in

--- a/src/support/hooks.ts
+++ b/src/support/hooks.ts
@@ -290,7 +290,7 @@ After({tags: '@delaylcp'}, async function (this: ICustomWorld) {
 /**
  * After each test scenario with the @renewal or @promo tag, performs teardown tasks.
  */
-After({tags: '@renewal or @promo'}, async function (this: ICustomWorld) {
+After({tags: '@renewal or @promo or @cache'}, async function (this: ICustomWorld) {
     await reactivatePlugin(TEST_HELPER_PLUGIN);
 });
 

--- a/src/support/steps/cache.ts
+++ b/src/support/steps/cache.ts
@@ -1,0 +1,42 @@
+/**
+ * @fileoverview
+ * This module contains Cucumber step definitions using Playwright for cache-related assertions,
+ * relying on the e2e test helper plugin's Cache tab to observe whether the homepage cache file
+ * exists and whether it was preserved (not regenerated) across an admin request.
+ *
+ * @requires {@link ../../common/custom-world}
+ * @requires {@link @playwright/test}
+ * @requires {@link @cucumber/cucumber}
+ */
+import { expect } from "@playwright/test";
+import { ICustomWorld } from "../../common/custom-world";
+import { Then, When } from '@cucumber/cucumber';
+
+/**
+ * Executes the step to refresh the WP Rocket settings page.
+ */
+When('I refresh WP Rocket settings', async function (this: ICustomWorld) {
+    await this.utils.gotoWpr();
+});
+
+/**
+ * Executes the step to assert that the homepage cache file exists.
+ */
+Then('homepage cache should exist', async function (this: ICustomWorld) {
+    // Navigate to helper plugin page.
+    await this.utils.gotoHelper();
+    // Go to cache tab
+    await this.page.locator('#cache_tab').click();
+    await expect(this.page.getByText('Cached', { exact: true })).toBeVisible();
+});
+
+/**
+ * Executes the step to assert that the homepage cache was not regenerated.
+ */
+Then('homepage cache should not be regenerated', async function (this: ICustomWorld) {
+    // Navigate to helper plugin page.
+    await this.utils.gotoHelper();
+    // Go to cache tab
+    await this.page.locator('#cache_tab').click();
+    await expect(this.page.locator('#should_not_regenerate_cache_on_admin_refresh')).toHaveText(/Preserved/);
+});


### PR DESCRIPTION
# Description
Done by AI + discussions

Fixes #383 
Capture cache clear regression using helper https://github.com/wp-media/wp-rocket-e2e-test-helper/pull/15
## Type of change

- [ ] New feature (non-breaking change which adds functionality).
- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] Enhancement (non-breaking change which improves an existing functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as before).
- [ ] Sub-task of #(issue number)
- [ ] Chore
- [ ] Release

## Detailed scenario

### What was tested

- Run the test with buggy zip & the helper PR => test fails
- Run the test with good zip and the helper PR => test pass

### How to test

- Run all e2e , should be green

### Affected Features & Quality Assurance Scope

N/A

## Technical description

### Documentation

- Cache home then refresh admin then check if cache is preserved
- Note: with current version of helper, cache step itself won't pass as login to admin will clear cache with buggy zip (good that test is failing)

### New dependencies

- New version of helper plugin

### Risks

N/A

# Mandatory Checklist

## Code validation

- [ ] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [ ] I implemented built-in tests to cover the new/changed code.

## Code style

- [ ] I wrote a self-explanatory code about what it does.
- [ ] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification

N/a
# Additional Checks
- [x] In the case of complex code, I wrote comments to explain it.
- [ ] When possible, I prepared ways to observe the implemented system (logs, data, etc.).
- [ ] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.)
